### PR TITLE
Migrate scenarios to DAML Scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   daml:
     docker:
-      - image: digitalasset/daml-sdk:1.2.0
+      - image: digitalasset/daml-sdk:1.5.0-snapshot.20200902.5118.0.2b3cf1b3
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   daml:
     docker:
-      - image: digitalasset/daml-sdk:1.5.0-snapshot.20200902.5118.0.2b3cf1b3
+      - image: digitalasset/daml-sdk:1.5.0
     steps:
       - checkout
       - setup_remote_docker

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.5.0-snapshot.20200902.5118.0.2b3cf1b3
+sdk-version: 1.5.0

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.2.0
+sdk-version: 1.5.0-snapshot.20200902.5118.0.2b3cf1b3

--- a/model/daml.yaml
+++ b/model/daml.yaml
@@ -1,10 +1,11 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.2.0
+sdk-version: 1.5.0-snapshot.20200902.5118.0.2b3cf1b3
 name: finlib
 version: 2.0.0
 source: src
 dependencies:
 - daml-prim
 - daml-stdlib
+- daml-script

--- a/model/daml.yaml
+++ b/model/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.5.0-snapshot.20200902.5118.0.2b3cf1b3
+sdk-version: 1.5.0
 name: finlib
 version: 2.0.0
 source: src

--- a/model/src/DA/Finance/Tutorial.daml
+++ b/model/src/DA/Finance/Tutorial.daml
@@ -2,6 +2,8 @@ daml 1.2
 
 module DA.Finance.Tutorial where
 
+import Daml.Script
+
 import DA.Next.Set
 import DA.Finance.Asset
 import DA.Finance.Asset.Settlement
@@ -17,15 +19,15 @@ In this tutorial we build up a model for retail transactions with increasing com
 
 {-
 
-We start with the simplest possible action: Alice deposits cash which her bank, AcmeBank, credits to an account. For this and the following scenarios we use the _unilateral_ trust model, where only the backer of an account signs the `AssetDeposit`. This simplifies some of the account setup procedures, but the transaction mechanics work the same way with different trust models.
+We start with the simplest possible action: Alice deposits cash which her bank, AcmeBank, credits to an account. For this and the following scripts we use the _unilateral_ trust model, where only the backer of an account signs the `AssetDeposit`. This simplifies some of the account setup procedures, but the transaction mechanics work the same way with different trust models.
 
 -}
 
-scenario1 = do
-  cb <- getParty "CentralBank"
-  acme <- getParty "AcmeBank"
-  alice <- getParty "Alice"
-  
+script1 = do
+  cb <- allocateParty "CentralBank"
+  acme <- allocateParty "AcmeBank"
+  alice <- allocateParty "Alice"
+
   let
     cbUsdId         = Id with signatories = fromList [ ]; label = "USD"; version = 0
     cbUsdAsset      = Asset with id = cbUsdId; quantity = 1_000.0
@@ -34,7 +36,7 @@ scenario1 = do
     aliceAccount    = Account with id = aliceAccountId; provider = acme; owner = alice
     aliceDeposit    = AssetDeposit with account = aliceAccount; asset = cbUsdAsset; observers = empty
 
-  aliceDepositCid <- submit acme do create aliceDeposit
+  aliceDepositCid <- submit acme do createCmd aliceDeposit
 
   pure ()
 
@@ -42,15 +44,15 @@ scenario1 = do
 
 Alice transfers money to Bob, who has an account with the same bank
 
-By default, `AssetDeposit`s are not transferrable. This is to allow scenarios where an asset's transferability needs to be restricted, for example if an asset vests over time. So for Alice to be able to transfer money to Bob, she requires an `AssetSettlementRule` contract. She also requires explicit grant from Bob to credit his account, which Bob can provide by adding her to the controllers on _his_ `AssetSettlementRule`.
+By default, `AssetDeposit`s are not transferrable. This is to allow scripts where an asset's transferability needs to be restricted, for example if an asset vests over time. So for Alice to be able to transfer money to Bob, she requires an `AssetSettlementRule` contract. She also requires explicit grant from Bob to credit his account, which Bob can provide by adding her to the controllers on _his_ `AssetSettlementRule`.
 
 -}
 
-scenario2 = do
-  cb <- getParty "CentralBank"
-  acme <- getParty "AcmeBank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+script2 = do
+  cb <- allocateParty "CentralBank"
+  acme <- allocateParty "AcmeBank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
 
   let
     cbUsdId         = Id with signatories = fromList [ cb ]; label = "USD"; version = 0
@@ -65,30 +67,30 @@ scenario2 = do
     bobAccount    = Account with id = bobAccountId; provider = acme; owner = bob
     bobSettlement = AssetSettlementRule with account = bobAccount; observers = empty; ctrls = fromList [ alice ]
 
-  aliceSettlementCid  <- submit acme do create aliceSettlement
-  bobSettlementCid    <- submit acme do create bobSettlement
+  aliceSettlementCid  <- submit acme do createCmd aliceSettlement
+  bobSettlementCid    <- submit acme do createCmd bobSettlement
 
-  aliceDepositCid <- submit acme do create aliceDeposit
+  aliceDepositCid <- submit acme do createCmd aliceDeposit
 
   bobDepositCid <- submit alice do
-    exercise aliceSettlementCid AssetSettlement_Transfer with
+    exerciseCmd aliceSettlementCid AssetSettlement_Transfer with
       receiverAccountId = bobAccountId
       depositCid = aliceDepositCid
 
   pure ()
-  
+
 {-
 
 Now, if Bob would hold his account at a different bank a direct transfer doesn't work anymore as in this case the authorization from Bob's bank to credit his account is missing.
 
 -}
 
-scenario3 = do
-  cb <- getParty "CentralBank"
-  acme <- getParty "AcmeBank"
-  genco <- getParty "GencoBank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+script3 = do
+  cb <- allocateParty "CentralBank"
+  acme <- allocateParty "AcmeBank"
+  genco <- allocateParty "GencoBank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
 
   let
     cbUsdId         = Id with signatories = fromList [ cb ]; label = "USD"; version = 0
@@ -103,28 +105,28 @@ scenario3 = do
     bobAccount    = Account with id = bobAccountId; provider = genco; owner = bob
     bobSettlement = AssetSettlementRule with account = bobAccount; observers = empty; ctrls = fromList [ alice ]
 
-  aliceSettlementCid  <- submit acme do create aliceSettlement
-  bobSettlementCid    <- submit genco do create bobSettlement
+  aliceSettlementCid  <- submit acme do createCmd aliceSettlement
+  bobSettlementCid    <- submit genco do createCmd bobSettlement
 
-  aliceDepositCid <- submit acme do create aliceDeposit
+  aliceDepositCid <- submit acme do createCmd aliceDeposit
 
   submitMustFail alice do
-    exercise aliceSettlementCid AssetSettlement_Transfer with
+    exerciseCmd aliceSettlementCid AssetSettlement_Transfer with
       receiverAccountId = bobAccountId
       depositCid = aliceDepositCid
 
-{- 
+{-
 
-This also intuitively makes sense, as directly transferring Alice's deposit to Bob would create a net new claim against Bob's bank without receiving offsetting funds from Alice's bank. So to model such a cross-entity transfer we have to implement settlement across multiple steps. First, Alice transfers the funds to Bob's bank, which needs to also hold an account with Alice's bank for this case. Then, Bob's bank can credit Bob's account with the same amount, as they now hold offseting funds at Alice's bank and are therefore net flat on the transaction. To do this, Bob's bank first creates an asset deposit for itself, which it then transfers to Bob.
+This also intuitively makes sense, as directly transferring Alice's deposit to Bob would createCmd a net new claim against Bob's bank without receiving offsetting funds from Alice's bank. So to model such a cross-entity transfer we have to implement settlement across multiple steps. First, Alice transfers the funds to Bob's bank, which needs to also hold an account with Alice's bank for this case. Then, Bob's bank can credit Bob's account with the same amount, as they now hold offseting funds at Alice's bank and are therefore net flat on the transaction. To do this, Bob's bank first creates an asset deposit for itself, which it then transfers to Bob.
 
 -}
 
-scenario4 = do
-  cb <- getParty "CentralBank"
-  acme <- getParty "AcmeBank"
-  genco <- getParty "GencoBank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+script4 = do
+  cb <- allocateParty "CentralBank"
+  acme <- allocateParty "AcmeBank"
+  genco <- allocateParty "GencoBank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
 
   let
     cbUsdId             = Id with signatories = fromList [ cb ]; label = "USD"; version = 0
@@ -147,20 +149,20 @@ scenario4 = do
     gencoOwnSettlement  = AssetSettlementRule with account = gencoOwnAccount; observers = empty; ctrls = empty
     gencoDeposit        = AssetDeposit with account = gencoOwnAccount; asset = cbUsdAsset; observers = empty
 
-  aliceSettlementCid    <- submit acme do create aliceSettlement
-  bobSettlementCid      <- submit genco do create bobSettlement
-  gencoSettlementCid    <- submit acme do create gencoSettlement
-  gencoOwnSettlementCid <- submit genco do create gencoOwnSettlement
+  aliceSettlementCid    <- submit acme do createCmd aliceSettlement
+  bobSettlementCid      <- submit genco do createCmd bobSettlement
+  gencoSettlementCid    <- submit acme do createCmd gencoSettlement
+  gencoOwnSettlementCid <- submit genco do createCmd gencoOwnSettlement
 
-  aliceDepositCid       <- submit acme do create aliceDeposit
-  gencoOwnDepositCid    <- submit genco do create gencoDeposit
+  aliceDepositCid       <- submit acme do createCmd aliceDeposit
+  gencoOwnDepositCid    <- submit genco do createCmd gencoDeposit
 
   gencoDepositCid       <- submit alice do
-    exercise aliceSettlementCid AssetSettlement_Transfer with
+    exerciseCmd aliceSettlementCid AssetSettlement_Transfer with
       receiverAccountId = gencoAccountId
       depositCid = aliceDepositCid
   bobDepositCid         <- submit genco do
-    exercise gencoOwnSettlementCid AssetSettlement_Transfer with
+    exerciseCmd gencoOwnSettlementCid AssetSettlement_Transfer with
       receiverAccountId = bobAccountId
       depositCid = gencoOwnDepositCid
 
@@ -173,11 +175,11 @@ In the above transaction GencoBank ends up with a deposit at AcmeBank to offset 
 -}
 
 scneario5 = do
-  cb <- getParty "CentralBank"
-  acme <- getParty "AcmeBank"
-  genco <- getParty "GencoBank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+  cb <- allocateParty "CentralBank"
+  acme <- allocateParty "AcmeBank"
+  genco <- allocateParty "GencoBank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
 
   let
     cbUsdId         = Id with signatories = fromList [ cb ]; label = "USD@CB"; version = 0
@@ -209,27 +211,27 @@ scneario5 = do
     acmeDeposit     = AssetDeposit with account = acmeAccount; asset = cbUsdAsset; observers = empty
     gencoDeposit    = AssetDeposit with account = gencoOwnAccount; asset = cbUsdAsset; observers = empty
 
-  aliceSettlementCid <- submit acme do create aliceSettlement
-  bobSettlementCid <- submit genco do create bobSettlement
-  acmeSettlementCid <- submit cb do create acmeSettlement
-  acmeOwnSettlementCid <- submit acme do create acmeOwnSettlement
-  gencoSettlementCid <- submit cb do create gencoSettlement
-  gencoOwnSettlementCid <- submit genco do create gencoOwnSettlement
+  aliceSettlementCid <- submit acme do createCmd aliceSettlement
+  bobSettlementCid <- submit genco do createCmd bobSettlement
+  acmeSettlementCid <- submit cb do createCmd acmeSettlement
+  acmeOwnSettlementCid <- submit acme do createCmd acmeOwnSettlement
+  gencoSettlementCid <- submit cb do createCmd gencoSettlement
+  gencoOwnSettlementCid <- submit genco do createCmd gencoOwnSettlement
 
-  aliceDepositCid <- submit acme do create aliceDeposit
-  acmeDepositCid  <- submit cb do create acmeDeposit
-  gencoDepositCid  <- submit genco do create gencoDeposit
+  aliceDepositCid <- submit acme do createCmd aliceDeposit
+  acmeDepositCid  <- submit cb do createCmd acmeDeposit
+  gencoDepositCid  <- submit genco do createCmd gencoDeposit
 
   aliceToAcmeDepositCid <- submit alice do
-    exercise aliceSettlementCid AssetSettlement_Transfer with
+    exerciseCmd aliceSettlementCid AssetSettlement_Transfer with
       receiverAccountId = acmeOwnAccountId
       depositCid = aliceDepositCid
   acmeToGencoDepositCid <- submit acme do
-    exercise acmeSettlementCid AssetSettlement_Transfer with
+    exerciseCmd acmeSettlementCid AssetSettlement_Transfer with
       receiverAccountId = gencoAccountId
       depositCid = acmeDepositCid
   gencoToBobDepositCid <- submit genco do
-    exercise gencoOwnSettlementCid AssetSettlement_Transfer with
+    exerciseCmd gencoOwnSettlementCid AssetSettlement_Transfer with
       receiverAccountId = bobAccountId
       depositCid = gencoDepositCid
 
@@ -237,7 +239,7 @@ scneario5 = do
 
 {-
 
-For the above transaction we need three individual transfers of assets, which represent three distinct points of failure. If any of the intermediaries fails to execute a transfer, but other transfers have already gone through, we can end up in very complex error recovery situations. These failure modes happen in real life and are operationally very expensive to rectify. Ideally, we would be able to execute the full settlement chain atomically, such that either all transfers execute, or none at all. The `DvP` (delivery-versus-payment) template in the Finance SDK provides this functionality and allows to settle arbitrarily complex chains of deliveries and payments atomically. A DvP trade is created together with a set of `SettlementInstruction`s, which detail the various settlement steps that need to happen for the given trade. These instructions are usually specific to a given use case so the Finance SDK doesn't provide a standard way to create them along with the DvP. So to model the example above we introduct a new template `DvpProposal`, which contains the logic to create the settlement instructions for a transfer of assets between Alice and Bob.
+For the above transaction we need three individual transfers of assets, which represent three distinct points of failure. If any of the intermediaries fails to execute a transfer, but other transfers have already gone through, we can end up in very complex error recovery situations. These failure modes happen in real life and are operationally very expensive to rectify. Ideally, we would be able to execute the full settlement chain atomically, such that either all transfers execute, or none at all. The `DvP` (delivery-versus-payment) template in the Finance SDK provides this functionality and allows to settle arbitrarily complex chains of deliveries and payments atomically. A DvP trade is created together with a set of `SettlementInstruction`s, which detail the various settlement steps that need to happen for the given trade. These instructions are usually specific to a given use case so the Finance SDK doesn't provide a standard way to createCmd them along with the DvP. So to model the example above we introduct a new template `DvpProposal`, which contains the logic to createCmd the settlement instructions for a transfer of assets between Alice and Bob.
 
 -}
 
@@ -284,12 +286,12 @@ template DvpProposal
           dsCid <- create dvpSettlement
           pure (dvpCid, siCid, dsCid)
 
-scenario6 = do
-  cb <- getParty "CentralBank"
-  acme <- getParty "AcmeBank"
-  genco <- getParty "GencoBank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+script6 = do
+  cb <- allocateParty "CentralBank"
+  acme <- allocateParty "AcmeBank"
+  genco <- allocateParty "GencoBank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
 
   let
     cbUsdId         = Id with signatories = fromList [ cb ]; label = "USD@CB"; version = 0
@@ -331,26 +333,26 @@ scenario6 = do
       counterpartyBankAccount = gencoAccount
       counterpartyBankOwnAccount = gencoOwnAccount
 
-  aliceSettlementCid <- submit acme do create aliceSettlement
-  bobSettlementCid <- submit genco do create bobSettlement
-  acmeSettlementCid <- submit cb do create acmeSettlement
-  acmeOwnSettlementCid <- submit acme do create acmeOwnSettlement
-  gencoSettlementCid <- submit cb do create gencoSettlement
-  gencoOwnSettlementCid <- submit genco do create gencoOwnSettlement
+  aliceSettlementCid <- submit acme do createCmd aliceSettlement
+  bobSettlementCid <- submit genco do createCmd bobSettlement
+  acmeSettlementCid <- submit cb do createCmd acmeSettlement
+  acmeOwnSettlementCid <- submit acme do createCmd acmeOwnSettlement
+  gencoSettlementCid <- submit cb do createCmd gencoSettlement
+  gencoOwnSettlementCid <- submit genco do createCmd gencoOwnSettlement
 
-  aliceDepositCid <- submit acme do create aliceDeposit
-  acmeDepositCid  <- submit cb do create acmeDeposit
-  gencoDepositCid  <- submit genco do create gencoDeposit
+  aliceDepositCid <- submit acme do createCmd aliceDeposit
+  acmeDepositCid  <- submit cb do createCmd acmeDeposit
+  gencoDepositCid  <- submit genco do createCmd gencoDeposit
 
-  dvpProposalCid <- submit alice do create dvpProposal
-  (dvpCid, siCid, dsCid) <- submit bob do exercise dvpProposalCid Accept
+  dvpProposalCid <- submit alice do createCmd dvpProposal
+  (dvpCid, siCid, dsCid) <- submit bob do exerciseCmd dvpProposalCid Accept
 
-  siCid <- submit alice do exercise siCid SettlementInstruction_AllocateNext with depositCid = aliceDepositCid; ctrl = alice
-  siCid <- submit acme do exercise siCid SettlementInstruction_AllocateNext with depositCid = acmeDepositCid; ctrl = acme
-  siCid <- submit genco do exercise siCid SettlementInstruction_AllocateNext with depositCid = gencoDepositCid; ctrl = genco
-  
+  siCid <- submit alice do exerciseCmd siCid SettlementInstruction_AllocateNext with depositCid = aliceDepositCid; ctrl = alice
+  siCid <- submit acme do exerciseCmd siCid SettlementInstruction_AllocateNext with depositCid = acmeDepositCid; ctrl = acme
+  siCid <- submit genco do exerciseCmd siCid SettlementInstruction_AllocateNext with depositCid = gencoDepositCid; ctrl = genco
+
   submit alice do
-    exercise dsCid DvpSettlement_Process with
+    exerciseCmd dsCid DvpSettlement_Process with
       dvpCid
       paymentInstructionCids = [ siCid ]
       deliveryInstructionCids = []
@@ -359,16 +361,16 @@ scenario6 = do
 
 {-
 
-One downside of this model is that the banks have to provide liquidity via central bank deposits to facilitate the transaction due to the non-fungibility of each bank's deposits. To remediate this complexity it would require that the banks' clients would have access to the same central bank-backed USD asset and accounts as their banks. This is the main idea behind the concept of Central Bank Digital Currency, which is frequently discussed these days. We can use the flexible trust model in the Finance SDK to model such a setup. We still retain the hierarchy of clients holding accounts with their banks, and the bank holding accounts at the central bank. But we can use the central bank as the "3rd party agent" signatory on the client accounts. This way Bob can directly transfer assets ot Charlie without an offseting transaction at the central bank level and without involvement of their banks. In this scenario the USD deposits at their banks in effect don't represent claims against their banks anymore, they are claims held by the clients against the central bank. Note, that such a setup is dependent on having a legal framework in place that would let clients access and transfer those deposits even in the event of a default of their bank.
+One downside of this model is that the banks have to provide liquidity via central bank deposits to facilitate the transaction due to the non-fungibility of each bank's deposits. To remediate this complexity it would require that the banks' clients would have access to the same central bank-backed USD asset and accounts as their banks. This is the main idea behind the concept of Central Bank Digital Currency, which is frequently discussed these days. We can use the flexible trust model in the Finance SDK to model such a setup. We still retain the hierarchy of clients holding accounts with their banks, and the bank holding accounts at the central bank. But we can use the central bank as the "3rd party agent" signatory on the client accounts. This way Bob can directly transfer assets ot Charlie without an offseting transaction at the central bank level and without involvement of their banks. In this script the USD deposits at their banks in effect don't represent claims against their banks anymore, they are claims held by the clients against the central bank. Note, that such a setup is dependent on having a legal framework in place that would let clients access and transfer those deposits even in the event of a default of their bank.
 
 -}
 
-scenario7 = do
-  cb <- getParty "CentralBank"
-  acme <- getParty "AcmeBank"
-  genco <- getParty "GencoBank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+script7 = do
+  cb <- allocateParty "CentralBank"
+  acme <- allocateParty "AcmeBank"
+  genco <- allocateParty "GencoBank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
 
   let
     cbUsdId         = Id with signatories = fromList [ cb ]; label = "USD"; version = 0
@@ -383,20 +385,20 @@ scenario7 = do
     bobAccount    = Account with id = bobAccountId; provider = genco; owner = bob
     bobSettlement = AssetSettlementRule with account = bobAccount; observers = empty; ctrls = fromList [ alice ]
 
-  aliceSettlementCid  <- submit cb do create aliceSettlement
-  bobSettlementCid    <- submit cb do create bobSettlement
+  aliceSettlementCid  <- submit cb do createCmd aliceSettlement
+  bobSettlementCid    <- submit cb do createCmd bobSettlement
 
-  aliceDepositCid <- submit cb do create aliceDeposit
+  aliceDepositCid <- submit cb do createCmd aliceDeposit
 
   bobDepositCid <- submit alice do
-    exercise aliceSettlementCid AssetSettlement_Transfer with
+    exerciseCmd aliceSettlementCid AssetSettlement_Transfer with
       receiverAccountId = bobAccountId
       depositCid = aliceDepositCid
 
   pure ()
 
 {-
-In this model we have chosen the bank as the only signatory on the account, which means it can directly create the `AssetDeposit` for Alice. We refer to this as the _unilateral trust model_, where only the account provider signs deposits. This means that the bank is allowed to credit Alice with arbitrary assets, which might not be desirable from Alice's perspective as some assets carry associated obligations with it (eg. a loan). Therefore, we can move this to a _bilateral trust model_ where both the account provider and the owner have to sign a deposit. Since the `AssetDeposit` now cannot be created by the bank alone anymore, we have to establish a workflow to also collect Alice's signature. This could for example be done via an `AssetDepositRequest` template, that Alice creates for the bank to process. Another way is for the bank to first create an `AssetDeposit` for itself (which it can since it's both, the provider and the owner of its account), and then transfer the deposit to Alice using Alice's `AssetSettlementRule`. This rule contract explicitly grants the permission to credit Alice's , which 
+In this model we have chosen the bank as the only signatory on the account, which means it can directly createCmd the `AssetDeposit` for Alice. We refer to this as the _unilateral trust model_, where only the account provider signs deposits. This means that the bank is allowed to credit Alice with arbitrary assets, which might not be desirable from Alice's perspective as some assets carry associated obligations with it (eg. a loan). Therefore, we can move this to a _bilateral trust model_ where both the account provider and the owner have to sign a deposit. Since the `AssetDeposit` now cannot be created by the bank alone anymore, we have to establish a workflow to also collect Alice's signature. This could for example be done via an `AssetDepositRequest` template, that Alice creates for the bank to process. Another way is for the bank to first createCmd an `AssetDeposit` for itself (which it can since it's both, the provider and the owner of its account), and then transfer the deposit to Alice using Alice's `AssetSettlementRule`. This rule contract explicitly grants the permission to credit Alice's , which
 
 Alice deposits cash into her account at the bank
 

--- a/test/daml.yaml
+++ b/test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.2.0
+sdk-version: 1.5.0-snapshot.20200902.5118.0.2b3cf1b3
 name: finlib-test
 version: 2.0.0
 source: src

--- a/test/daml.yaml
+++ b/test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.5.0-snapshot.20200902.5118.0.2b3cf1b3
+sdk-version: 1.5.0
 name: finlib-test
 version: 2.0.0
 source: src

--- a/test/src/Test/Finance/Asset.daml
+++ b/test/src/Test/Finance/Asset.daml
@@ -6,45 +6,49 @@ module Test.Finance.Asset where
 
 import DA.Assert
 import DA.Finance.Asset
+import qualified DA.Next.Map as Map
+import Daml.Script
 
 import Test.Finance.Market.Asset
 import Test.Finance.Market.Party
 import Test.Finance.Types
 import Test.Finance.Utils
 
-matchAssetDeposit (cid : ContractId AssetDeposit) provider owner label version quantity =
-  submit owner do
-    c <- fetch cid
-    c.account.provider === provider
-    c.account.owner === owner
-    c.asset.id.label === label
-    c.asset.id.version === version
-    c.asset.quantity === quantity
+matchAssetDeposit (cid : ContractId AssetDeposit) provider owner label version quantity = do
+  Some c <- queryContractId owner cid
+  c.account.provider === provider
+  c.account.owner === owner
+  c.asset.id.label === label
+  c.asset.id.version === version
+  c.asset.quantity === quantity
 
 -- | Test for AssetDeposit choices.
-testAssetFungible : TrustModel -> Scenario ()
-testAssetFungible trustModel = scenario do
+testAssetFungible : TrustModel -> Script ()
+testAssetFungible trustModel = script do
   p@Parties{..} <- partySetup
   let info = [ AssetInfo with provider = acmeBank, owner = alice, accountType = None, assetData = [("USD", 1000.0)] ]
   a@AssetMarket{..} <- assetSetup p trustModel info
 
   [deposit1Cid, deposit2Cid, deposit3Cid, deposit4Cid] <- submit alice do
-    exercise (depositMap ! "Alice@AcmeBank:USD:0:1000.0") AssetDeposit_Split with
+    exerciseCmd (depositMap ! "Alice@AcmeBank:USD:0:1000.0") AssetDeposit_Split with
       quantities = [100.0, 200.0, 600.0]
 
   deposit5Cid <- submit alice do
-    exercise deposit1Cid AssetDeposit_Merge with
+    exerciseCmd deposit1Cid AssetDeposit_Merge with
       depositCids = [deposit2Cid, deposit3Cid]
 
   matchAssetDeposit deposit4Cid acmeBank alice "USD" 0 100.0
   matchAssetDeposit deposit5Cid acmeBank alice "USD" 0 900.0
 
-  submitMustFail alice do fetch $ depositMap ! "Alice@AcmeBank:USD:0:1000"
-  submitMustFail alice do fetch deposit1Cid
-  submitMustFail alice do fetch deposit2Cid
+  let optDepositCid = Map.lookup "Alice@AcmeBank:USD:0:1000" depositMap
+  optDepositCid === None
+  optDeposit <- queryContractId alice deposit1Cid
+  optDeposit === None
+  optDeposit <- queryContractId alice deposit2Cid
+  optDeposit === None
 
   submitMustFail alice do
-    exercise deposit3Cid AssetDeposit_Split with
+    exerciseCmd deposit3Cid AssetDeposit_Split with
       quantities = [500.0, 500.0]
 
 testAssetFungible_Bilateral = testAssetFungible TrustModel_Bilateral

--- a/test/src/Test/Finance/Asset/Settlement.daml
+++ b/test/src/Test/Finance/Asset/Settlement.daml
@@ -5,7 +5,9 @@ daml 1.2
 module Test.Finance.Asset.Settlement where
 
 import DA.Assert
+import qualified DA.Next.Map as Map
 import DA.Next.Set as Set
+import Daml.Script
 
 import DA.Finance.Asset
 import DA.Finance.Asset.Settlement
@@ -17,23 +19,25 @@ import Test.Finance.Types
 import Test.Finance.Utils
 
 -- | Test for AssetSettlementRule.
-testAssetSettlement : Parties -> TrustModel -> Scenario AssetDeposit
-testAssetSettlement p@Parties{..} trustModel = scenario do
-  let info = 
+testAssetSettlement : Parties -> TrustModel -> Script AssetDeposit
+testAssetSettlement p@Parties{..} trustModel = script do
+  let info =
         [ AssetInfo with provider = acmeBank, owner = alice, accountType = None, assetData = [("USD", 1000.0)]
         , AssetInfo with provider = acmeBank, owner = bob, accountType = None, assetData = []
         ]
   a@AssetMarket{..} <- assetSetup p trustModel info
 
   depositCid <- submit alice do
-    exerciseByKey @AssetSettlementRule (accountMap ! "Alice@AcmeBank").id AssetSettlement_Transfer with
+    exerciseByKeyCmd @AssetSettlementRule (accountMap ! "Alice@AcmeBank").id AssetSettlement_Transfer with
       receiverAccountId = (accountMap ! "Bob@AcmeBank").id
       depositCid = depositMap ! "Alice@AcmeBank:USD:0:1000.0"
 
   matchAssetDeposit depositCid acmeBank bob "USD" 0 1000.0
-  submitMustFail alice do fetch $ depositMap ! "Alice@AcmeBank:USD:1000"
+  let optDeposit = Map.lookup "Alice@AcmeBank:USD:1000" depositMap
+  optDeposit === None
 
-  submit bob do fetch depositCid
+  Some assetDeposit <- queryContractId bob depositCid
+  pure assetDeposit
 
 testAssetSettlement_Bilateral = do
   p@Parties{..} <- partySetup

--- a/test/src/Test/Finance/Base/HolidayCalendar.daml
+++ b/test/src/Test/Finance/Base/HolidayCalendar.daml
@@ -3,6 +3,7 @@ module Test.Finance.Base.HolidayCalendar where
 
 import DA.Assert
 import DA.Date
+import Daml.Script
 
 import DA.Finance.Base.HolidayCalendar
 
@@ -12,31 +13,31 @@ cal = HolidayCalendarData with
         weekend = [Saturday, Sunday]
         holidays = [date 2018 Jan 02, date 2018 Jan 31, date 2018 Feb 1]
 
-test_isHoliday = scenario do
+test_isHoliday = script do
   isHoliday cal (date 2018 Jan 02) === True
 
-test_isBusinessDay = scenario do
+test_isBusinessDay = script do
   isBusinessDay cal (date 2018 Jan 02) === False
 
-test_nextBusinessDay = scenario do
+test_nextBusinessDay = script do
   nextBusinessDay cal (date 2018 Jan 01) === date 2018 Jan 03
 
-test_previousBusinessDay = scenario do
+test_previousBusinessDay = script do
   previousBusinessDay cal (date 2018 Jan 03) === date 2018 Jan 01
 
-test_nextOrSameBusinessDay = scenario do
+test_nextOrSameBusinessDay = script do
   nextOrSameBusinessDay cal (date 2018 Jan 01) === date 2018 Jan 01
 
-test_previousOrSameBusinessDay = scenario do
+test_previousOrSameBusinessDay = script do
   previousOrSameBusinessDay cal (date 2018 Jan 03) === date 2018 Jan 03
 
-test_nextSameOrLastInMonthBusinessDay = scenario do
+test_nextSameOrLastInMonthBusinessDay = script do
   nextSameOrLastInMonthBusinessDay cal (date 2018 Jan 31) === date 2018 Jan 30
-test_addBusinessDays = scenario do
+test_addBusinessDays = script do
   addBusinessDays cal 5 (date 2018 Jan 01) === date 2018 Jan 09
   addBusinessDays cal (-5) (date 2018 Feb 05) === date 2018 Jan 25
 
-test_adjustDate = scenario do
+test_adjustDate = script do
   adjustDate cal NONE (date 2018 Mar 31) === (date 2018 Mar 31)
   adjustDate cal FOLLOWING (date 2018 Mar 31) === (date 2018 Apr 02)
   adjustDate cal MODFOLLOWING (date 2018 Mar 31) === (date 2018 Mar 30)

--- a/test/src/Test/Finance/Base/RollConvention.daml
+++ b/test/src/Test/Finance/Base/RollConvention.daml
@@ -3,10 +3,11 @@ module Test.Finance.Base.RollConvention where
 
 import DA.Assert
 import DA.Date as D
+import Daml.Script
 
 import DA.Finance.Base.RollConvention
 
-test_addPeriod = scenario do
+test_addPeriod = script do
   addPeriod (D.date 2018 Oct 01) (Period {periodMultiplier = 1, period = D}) === D.date 2018 Oct 02
   addPeriod (D.date 2018 Oct 01) (Period {periodMultiplier = 1, period = W}) === D.date 2018 Oct 08
   addPeriod (D.date 2018 Oct 01) (Period {periodMultiplier = 1, period = M}) === D.date 2018 Nov 01
@@ -15,7 +16,7 @@ test_addPeriod = scenario do
   addPeriod (D.date 2018 Nov 30) (Period {periodMultiplier = -1, period = M}) === D.date 2018 Oct 30
   addPeriod (D.date 2018 Jan 30) (Period {periodMultiplier = -1, period = M}) === D.date 2017 Dec 30
 
-test_next = scenario do
+test_next = script do
   next (D.date 2018 Oct 31) (Period {periodMultiplier = 1, period = M}) EOM === D.date 2018 Nov 30
   next (D.date 2018 Oct 01) (Period {periodMultiplier = 1, period = M}) (DOM 1) === D.date 2018 Nov 01
   next (D.date 2018 Feb 28) (Period {periodMultiplier = 3, period = M}) (DOM 30) === D.date 2018 May 30

--- a/test/src/Test/Finance/Base/Schedule.daml
+++ b/test/src/Test/Finance/Base/Schedule.daml
@@ -4,6 +4,7 @@ module Test.Finance.Base.Schedule where
 import DA.Assert
 import DA.Date as D
 import DA.List
+import Daml.Script
 
 import DA.Finance.Base.HolidayCalendar
 import DA.Finance.Base.RollConvention
@@ -24,7 +25,7 @@ example = PeriodicSchedule {
               calendarIds = ["USNY"],
               convention = MODFOLLOWING
             },
-          effectiveDateBusinessDayAdjustment = None, 
+          effectiveDateBusinessDayAdjustment = None,
           terminationDateBusinessDayAdjustment = None,
           frequency =
             Frequency {
@@ -32,7 +33,7 @@ example = PeriodicSchedule {
               period = M,
               periodMultiplier = 3
             },
-          effectiveDate = D.date 2018 Nov 15, 
+          effectiveDate = D.date 2018 Nov 15,
           firstRegularPeriodStartDate = Some $ D.date 2018 Nov 30,
           lastRegularPeriodEndDate = Some $ D.date 2019 Nov 30,
           stubPeriodType = None,
@@ -92,28 +93,28 @@ setStubType : StubPeriodTypeEnum -> PeriodicSchedule -> PeriodicSchedule
 setStubType stubType schedule =
   schedule { stubPeriodType = Some stubType }
 
-test_base = scenario do
+test_base = script do
   createSchedule cals example === expectedResultBothStub
 
-test_reg_periods_only = scenario do
+test_reg_periods_only = script do
   -- Regular periods only
   let testCase = setDates (D.date 2018 Nov 30) None None (D.date 2019 Nov 30) example
   let expectedResult = (tail . init) expectedResultBothStub
   createSchedule cals testCase === expectedResult
 
-test_regStart_equal_effective_smaller_termination = scenario do
+test_regStart_equal_effective_smaller_termination = script do
   -- RegStart == Effective < Termination
   let testCase = setDates (D.date 2018 Nov 30) (Some $ D.date 2018 Nov 30) None (D.date 2019 Nov 30) example
   let expectedResult = (tail . init) expectedResultBothStub
   createSchedule cals testCase === expectedResult
 
-test_regStart_smaller_effective_smaller_termination = scenario do
+test_regStart_smaller_effective_smaller_termination = script do
   -- RegStart < Effective < Termination
   let testCase = setDates (D.date 2018 Nov 15) (Some $ D.date 2018 Nov 30) None (D.date 2019 Nov 30) example
   let expectedResult = init expectedResultBothStub
   createSchedule cals testCase === expectedResult
 
-test_effective_smaller_regStart_equal_termination = scenario do
+test_effective_smaller_regStart_equal_termination = script do
   -- Effective < RegStart == Termination
   let testCase = setDates (D.date 2018 Nov 15) (Some $ D.date 2019 Nov 30) None (D.date 2019 Nov 30) example
   let expectedResult =
@@ -126,7 +127,7 @@ test_effective_smaller_regStart_equal_termination = scenario do
         ]
   createSchedule cals testCase === expectedResult
 
-test_regEnd_equal_effective_smaller_termination = scenario do
+test_regEnd_equal_effective_smaller_termination = script do
   -- RegEnd == Effective < Termination
   let testCase = setDates (D.date 2018 Nov 30) None (Some $ D.date 2018 Nov 30) (D.date 2019 Nov 30) example
   let expectedResult =
@@ -139,18 +140,18 @@ test_regEnd_equal_effective_smaller_termination = scenario do
         ]
   createSchedule cals testCase === expectedResult
 
-test_effective_smaller_regEnd_smaller_termination = scenario do
+test_effective_smaller_regEnd_smaller_termination = script do
   -- Effective < RegEnd < Termination
   let testCase = setDates (D.date 2018 Nov 30) None (Some $ D.date 2019 Nov 30) (D.date 2019 Dec 15) example
   createSchedule cals testCase === tail expectedResultBothStub
 
-test_effective_smaller_termination_equal_regEnd = scenario do
+test_effective_smaller_termination_equal_regEnd = script do
   -- Effective < Termination == RegEnd
   let testCase = setDates (D.date 2018 Nov 30) None (Some $ D.date 2019 Nov 30) (D.date 2019 Nov 30) example
   let expectedResult = (tail . init) expectedResultBothStub
   createSchedule cals testCase === expectedResult
 
-test_effective_smaller_firstReg_equal_lastReg_smaller_termination = scenario do
+test_effective_smaller_firstReg_equal_lastReg_smaller_termination = script do
   -- Effective < FirstRegular == LastRegular < Termination
   let testCase = setDates (D.date 2018 Oct 15) (Some $ D.date 2019 Jan 30) (Some $ D.date 2019 Jan 30) (D.date 2019 Dec 15) example
   let expectedResult =
@@ -169,7 +170,7 @@ test_effective_smaller_firstReg_equal_lastReg_smaller_termination = scenario do
         ]
   createSchedule cals testCase === expectedResult
 
-test_shortInitial = scenario do
+test_shortInitial = script do
   -- Implicit Stubs
   -- exact match
   let testCase =
@@ -179,7 +180,7 @@ test_shortInitial = scenario do
   let expectedResult = (tail . init) expectedResultBothStub
   createSchedule cals testCase === expectedResult
 
-test_longFinal = scenario do
+test_longFinal = script do
   let testCase =
         setDates (D.date 2018 Nov 30) None None (D.date 2019 Nov 30)
         $ setStubType LONG_FINAL
@@ -187,7 +188,7 @@ test_longFinal = scenario do
   let expectedResult = (tail . init) expectedResultBothStub
   createSchedule cals testCase === expectedResult
 
-test_twoPeriods_shortInitial = scenario do
+test_twoPeriods_shortInitial = script do
   -- Two Periods SHORT_INITIAL
   let testCase =
         setDates (D.date 2018 Nov 15) None None (D.date 2019 Feb 28)
@@ -196,7 +197,7 @@ test_twoPeriods_shortInitial = scenario do
   let expectedResult = take 2 expectedResultBothStub
   createSchedule cals testCase === expectedResult
 
-test_twoPeriods_longInitial = scenario do
+test_twoPeriods_longInitial = script do
   -- Two Periods LONG_INITIAL
   let testCase =
         setDates (D.date 2018 Nov 15) None None (D.date 2019 Feb 28)
@@ -212,7 +213,7 @@ test_twoPeriods_longInitial = scenario do
         ]
   createSchedule cals testCase === expectedResult
 
-test_singlePeriod_shortInitial = scenario do
+test_singlePeriod_shortInitial = script do
   -- Single Period SHORT_INITIAL
   let testCase =
         setDates (D.date 2018 Nov 15) None None (D.date 2018 Nov 30)
@@ -221,7 +222,7 @@ test_singlePeriod_shortInitial = scenario do
   let expectedResult = take 1 expectedResultBothStub
   createSchedule cals testCase === expectedResult
 
-test_singlePeriod_longInitial = scenario do
+test_singlePeriod_longInitial = script do
   -- Single Period LONG_INITIAL
   let testCase =
         setDates (D.date 2018 Nov 15) None None (D.date 2018 Nov 30)
@@ -230,7 +231,7 @@ test_singlePeriod_longInitial = scenario do
   let expectedResult = take 1 expectedResultBothStub
   createSchedule cals testCase === expectedResult
 
-test_twoPeriods_shortFinal = scenario do
+test_twoPeriods_shortFinal = script do
   -- Two Periods SHORT_FINAL
   let testCase =
         setDates (D.date 2019 Aug 30) None None (D.date 2019 Dec 15)
@@ -239,7 +240,7 @@ test_twoPeriods_shortFinal = scenario do
   let expectedResult = drop 4 expectedResultBothStub
   createSchedule cals testCase === expectedResult
 
-test_twoPeriods_longFinal = scenario do
+test_twoPeriods_longFinal = script do
   -- Two Periods LONG_FINAL
   let testCase =
         setDates (D.date 2019 Aug 30) None None (D.date 2019 Dec 15)
@@ -255,7 +256,7 @@ test_twoPeriods_longFinal = scenario do
         ]
   createSchedule cals testCase === expectedResult
 
-test_singlePeriod_shortFinal = scenario do
+test_singlePeriod_shortFinal = script do
   -- Single Period SHORT_FINAL
   let testCase =
         setDates (D.date 2019 Nov 30) None None (D.date 2019 Dec 15)
@@ -271,7 +272,7 @@ test_singlePeriod_shortFinal = scenario do
         ]
   createSchedule cals testCase === expectedResult
 
-test_singlePeriod_longFinal = scenario do
+test_singlePeriod_longFinal = script do
   -- Single Period LONG_FINAL
   let testCase =
         setDates (D.date 2019 Nov 30) None None (D.date 2019 Dec 15)

--- a/test/src/Test/Finance/Instrument/Equity/Option.daml
+++ b/test/src/Test/Finance/Instrument/Equity/Option.daml
@@ -8,6 +8,8 @@ import DA.Assert
 import DA.Date
 import DA.List
 import DA.Next.Set as Set
+import DA.Time
+import Daml.Script
 
 import DA.Finance.Asset.Lifecycle
 import DA.Finance.Instrument.Entitlement
@@ -24,8 +26,8 @@ import Test.Finance.Market.Party
 import Test.Finance.Types hiding (CASH)
 import Test.Finance.Utils
 
-testStockSplit = scenario do
-  passToDate $ date 2020 Jan 1
+testStockSplit = script do
+  setTime (time (date 2020 Jan 1) 0 0 0)
 
   p@Parties{..} <- partySetup
 
@@ -44,41 +46,41 @@ testStockSplit = scenario do
         ]
   InstrumentMarket{..} <- instrumentSetup reuters observers stockInfo optionInfo
 
-  let assetInfo = 
+  let assetInfo =
         [ AssetInfo with provider = acmeBank, owner = alice, accountType = None, assetData = [("Option", 3.0)]
         ]
   am@AssetMarket{..} <- assetSetup p TrustModel_Bilateral assetInfo
 
   -- Stock split
   stockSplitCid <- submit reuters do
-    create EquityStockSplit with
+    createCmd EquityStockSplit with
       id = initAssetId reuters "DAH" 0
       exDate = date 2020 Jan 1
       rFactor = 0.5
       observers = Set.fromList $ map (.owner) assetInfo
 
   (optionCid, lifecycleEffectsCid) <- submit reuters do
-    exerciseByKey @EquityOptionStockSplitRule (Set.singleton reuters)
+    exerciseByKeyCmd @EquityOptionStockSplitRule (Set.singleton reuters)
        EquityOptionStockSplit_Lifecycle with
         optionCid = optionMap ! "Option"
         stockSplitCid
 
   [depositCid] <- submit alice do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
       depositCid = depositMap ! "Alice@AcmeBank:Option:0:3.0", lifecycleEffectsCid, accountIds = None, consumingDepositCids = []
 
   -- Checks
   matchAssetDeposit depositCid acmeBank alice "Option" 1 3.0
-  submitMustFail alice do fetch $ depositMap ! "Alice@AcmeBank:Option:0:3.0"
+  optDeposit <- queryContractId alice (depositMap ! "Alice@AcmeBank:Option:0:3.0")
+  optDeposit === None
 
-  submit reuters do
-    option <- fetch optionCid
-    option.strike === 5.0
-    option.contractSize === 2000.0
-    option.underlyingId === initAssetId reuters "DAH" 1
+  Some option <- queryContractId reuters optionCid
+  option.strike === 5.0
+  option.contractSize === 2000.0
+  option.underlyingId === initAssetId reuters "DAH" 1
 
-testExercise_CASH = scenario do
-  passToDate $ date 2020 Jan 1
+testExercise_CASH = script do
+  setTime (time (date 2020 Jan 1) 0 0 0)
 
   p@Parties{..} <- partySetup
 
@@ -97,7 +99,7 @@ testExercise_CASH = scenario do
         ]
   InstrumentMarket{..} <- instrumentSetup reuters observers stockInfo optionInfo
 
-  let assetInfo = 
+  let assetInfo =
         [ AssetInfo with provider = acmeBank, owner = alice, accountType = None, assetData = [("Option", 3.0)]
         , AssetInfo with provider = acmeBank, owner = charlie, accountType = None, assetData = [("Option", 3.0)]
         ]
@@ -105,7 +107,7 @@ testExercise_CASH = scenario do
 
   -- Cannot exercise before maturity
   submitMustFail reuters do
-    exerciseByKey @EquityOptionExerciseRule (Set.singleton reuters)
+    exerciseByKeyCmd @EquityOptionExerciseRule (Set.singleton reuters)
       EquityOptionExercise_Lifecycle with
         optionCid = optionMap ! "Option"
         underlyingPrice = None
@@ -113,40 +115,41 @@ testExercise_CASH = scenario do
         settlementDate = date 2020 Feb 3
 
   -- Create exercise lifecycle data
-  passToDate $ date 2020 Feb 1
+  setTime (time (date 2020 Feb 1) 0 0 0)
 
   (entitlementCid, lifecycleEffectsCid) <- submit reuters do
-    exerciseByKey @EquityOptionExerciseRule (Set.singleton reuters)
+    exerciseByKeyCmd @EquityOptionExerciseRule (Set.singleton reuters)
       EquityOptionExercise_Lifecycle with
         optionCid = optionMap ! "Option"
-        underlyingPrice = Some 15.0 
+        underlyingPrice = Some 15.0
         entitlementIdLabel = "Option:Exercise"
         settlementDate = date 2020 Feb 3
 
   -- Exercise option by owner
   [exerciseEntitlementCid] <- submit alice do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
       depositCid = depositMap ! "Alice@AcmeBank:Option:0:3.0", lifecycleEffectsCid, accountIds = None, consumingDepositCids = []
 
   matchAssetDeposit exerciseEntitlementCid acmeBank alice "Option:Exercise" 0 3.0
-  submitMustFail alice do fetch $ depositMap ! "Alice@AcmeBank:Option:0:3.0"
+  optDeposit <- queryContractId alice (depositMap ! "Alice@AcmeBank:Option:0:3.0")
+  optDeposit === None
 
   -- Exercise not possible on the next day
-  passToDate $ date 2020 Feb 2
+  setTime (time (date 2020 Feb 2) 0 0 0)
   submit reuters do
-    exercise lifecycleEffectsCid Archive
+    exerciseCmd lifecycleEffectsCid Archive
 
   submitMustFail charlie do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "Charlie@AcmeBank").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "Charlie@AcmeBank").id AssetLifecycle_Process with
       depositCid = depositMap ! "Charlie@AcmeBank:Option:0:3.0", lifecycleEffectsCid, accountIds = None, consumingDepositCids = []
 
   -- Process entitlement
-  passToDate $ date 2020 Feb 3
+  setTime (time (date 2020 Feb 3) 0 0 0)
   lifecycleEffectsCid <- submit reuters do
-    exercise entitlementCid Entitlement_Lifecycle
+    exerciseCmd entitlementCid Entitlement_Lifecycle
 
   [depositCid] <- submit alice do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
       depositCid = exerciseEntitlementCid
       lifecycleEffectsCid
       accountIds = None
@@ -154,10 +157,11 @@ testExercise_CASH = scenario do
 
   -- Checks
   matchAssetDeposit depositCid acmeBank alice "USD" 0 15000.0
-  submitMustFail alice do fetch $ exerciseEntitlementCid
+  optEntitlement <- queryContractId alice exerciseEntitlementCid
+  optEntitlement === None
 
-testExercise_PHYSICAL = scenario do
-  passToDate $ date 2020 Jan 1
+testExercise_PHYSICAL = script do
+  setTime (time (date 2020 Jan 1) 0 0 0)
 
   p@Parties{..} <- partySetup
 
@@ -176,16 +180,16 @@ testExercise_PHYSICAL = scenario do
         ]
   InstrumentMarket{..} <- instrumentSetup reuters observers stockInfo optionInfo
 
-  let assetInfo = 
+  let assetInfo =
         [ AssetInfo with provider = acmeBank, owner = alice, accountType = None, assetData = [("Option", 3.0), ("USD", 30000.0)]
         ]
   am@AssetMarket{..} <- assetSetup p TrustModel_Bilateral assetInfo
 
   -- Create exercise lifecycle data
-  passToDate $ date 2020 Feb 1
+  setTime (time (date 2020 Feb 1) 0 0 0)
 
   (entitlementCid, lifecycleEffectsCid) <- submit reuters do
-    exerciseByKey @EquityOptionExerciseRule (Set.singleton reuters)
+    exerciseByKeyCmd @EquityOptionExerciseRule (Set.singleton reuters)
       EquityOptionExercise_Lifecycle with
         optionCid = optionMap ! "Option"
         underlyingPrice = None
@@ -194,19 +198,20 @@ testExercise_PHYSICAL = scenario do
 
   -- Exercise option by owner
   [exerciseEntitlementCid] <- submit alice do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
       depositCid = depositMap ! "Alice@AcmeBank:Option:0:3.0", lifecycleEffectsCid, accountIds = None, consumingDepositCids = []
 
   matchAssetDeposit exerciseEntitlementCid acmeBank alice "Option:Exercise" 0 3.0
-  submitMustFail alice do fetch $ depositMap ! "Alice@AcmeBank:Option:0:3.0"
+  optDeposit <- queryContractId alice (depositMap ! "Alice@AcmeBank:Option:0:3.0")
+  optDeposit === None
 
   -- Process entitlement
-  passToDate $ date 2020 Feb 3
+  setTime (time (date 2020 Feb 3) 0 0 0)
   lifecycleEffectsCid <- submit reuters do
-    exercise entitlementCid Entitlement_Lifecycle
+    exerciseCmd entitlementCid Entitlement_Lifecycle
 
   [depositCid] <- submit alice do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
       depositCid = exerciseEntitlementCid
       lifecycleEffectsCid
       accountIds = None
@@ -214,10 +219,11 @@ testExercise_PHYSICAL = scenario do
 
   -- Checks
   matchAssetDeposit depositCid acmeBank alice "DAH" 0 3000.0
-  submitMustFail alice do fetch $ exerciseEntitlementCid
+  optEntitlement <- queryContractId alice exerciseEntitlementCid
+  optEntitlement === None
 
-test_Dvp = scenario do
-  passToDate $ date 2020 Jan 1
+test_Dvp = script do
+  setTime (time (date 2020 Jan 1) 0 0 0)
 
   p@Parties{..} <- partySetup
 
@@ -251,40 +257,38 @@ test_Dvp = scenario do
   dm@DvpMarket{..} <- dvpSetup p TrustModel_Bilateral tradeInfo
 
   -- Create exercise lifecycle data
-  passToDate $ date 2020 Feb 1
+  setTime (time (date 2020 Feb 1) 0 0 0)
 
   (entitlementCid, lifecycleEffectsCid) <- submit reuters do
-    exerciseByKey @EquityOptionExerciseRule (Set.singleton reuters)
+    exerciseByKeyCmd @EquityOptionExerciseRule (Set.singleton reuters)
       EquityOptionExercise_Lifecycle with
         optionCid = optionMap ! "Option"
         underlyingPrice = None
         entitlementIdLabel = "Option:Exercise"
         settlementDate = date 2020 Feb 3
 
-  -- Exercise option 
+  -- Exercise option
   dvp1Cid <- submit alice do
-    exerciseByKey @DvpLifecycleRule (maIdMap ! "Charlie&Alice") DvpLifecycle_Process with
+    exerciseByKeyCmd @DvpLifecycleRule (maIdMap ! "Charlie&Alice") DvpLifecycle_Process with
       dvpCid = dvpMap ! "Charlie&Alice:Dvp:0", lifecycleEffectsCid, ctrl = alice
 
   -- Checks
-  submit alice do
-    dvp1 <- fetch dvp1Cid
-    dvp1.tradeId.version === 1
-    dvp1.payments !! 0 === initAsset reuters "Option:Exercise" 0 3.0
-    dvp1.deliveries === []
+  Some dvp1 <- queryContractId alice dvp1Cid
+  dvp1.tradeId.version === 1
+  dvp1.payments !! 0 === initAsset reuters "Option:Exercise" 0 3.0
+  dvp1.deliveries === []
 
   -- Process entitlement
-  passToDate $ date 2020 Feb 3
+  setTime (time (date 2020 Feb 3) 0 0 0)
   lifecycleEffectsCid <- submit reuters do
-    exercise entitlementCid Entitlement_Lifecycle
+    exerciseCmd entitlementCid Entitlement_Lifecycle
 
   dvp2Cid <- submit alice do
-    exerciseByKey @DvpLifecycleRule (maIdMap ! "Charlie&Alice") DvpLifecycle_Process with
+    exerciseByKeyCmd @DvpLifecycleRule (maIdMap ! "Charlie&Alice") DvpLifecycle_Process with
       dvpCid = dvp1Cid, lifecycleEffectsCid, ctrl = alice
 
   -- Checks
-  submit alice do
-    dvp2 <- fetch dvp2Cid
-    dvp2.tradeId.version === 2
-    dvp2.payments !! 0 === initAsset reuters "DAH" 0 3000.0
-    dvp2.deliveries !! 0 === initAsset reuters "USD" 0 30000.0
+  Some dvp2 <- queryContractId alice dvp2Cid
+  dvp2.tradeId.version === 2
+  dvp2.payments !! 0 === initAsset reuters "DAH" 0 3000.0
+  dvp2.deliveries !! 0 === initAsset reuters "USD" 0 30000.0

--- a/test/src/Test/Finance/Instrument/Equity/Stock.daml
+++ b/test/src/Test/Finance/Instrument/Equity/Stock.daml
@@ -8,6 +8,9 @@ import DA.Assert
 import DA.Date
 import DA.List
 import DA.Next.Set as Set
+import qualified DA.Next.Map as Map
+import DA.Time
+import Daml.Script
 
 import DA.Finance.Asset.Lifecycle
 import DA.Finance.Instrument.Entitlement
@@ -25,12 +28,12 @@ import Test.Finance.Market.Party
 import Test.Finance.Types
 import Test.Finance.Utils
 
-testEquityCashDividend = scenario do
-  passToDate $ date 2020 Jan 1
+testEquityCashDividend = script do
+  setTime (time (date 2020 Jan 1) 0 0 0)
 
   p@Parties{..} <- partySetup
 
-  let assetInfo = 
+  let assetInfo =
         [ AssetInfo with provider = acmeBank, owner = alice, accountType = Some SHARE, assetData = [("DAH", 50.0)]
         , AssetInfo with provider = acmeBank, owner = alice, accountType = Some CASH, assetData = []
         , AssetInfo with provider = csd, owner = acmeBank, accountType = Some SHARE, assetData = [("DAH", 50.0)]
@@ -41,7 +44,7 @@ testEquityCashDividend = scenario do
   let stockInfo = [ StockInfo with ccyLabel = "USD", stockLabel = "DAH"]
   let observers = Set.fromList $ map (.owner) assetInfo
   InstrumentMarket{..} <- instrumentSetup reuters observers stockInfo []
-  
+
   let tradeInfo =
         [ TradeInfo with
             buyer = charlie
@@ -58,7 +61,7 @@ testEquityCashDividend = scenario do
 
   -- Dividend
   dividendCid <- submit reuters do
-    create EquityCashDividend with
+    createCmd EquityCashDividend with
       id = initAssetId reuters "DAH" 0
       exDate = date 2020 Jan 1
       settlementDate = date 2020 Jan 5
@@ -67,26 +70,26 @@ testEquityCashDividend = scenario do
 
   -- Process equity cash dividend corporate action.
   (_, entitlementCid, lifecycleEffectsCid) <- submit reuters do
-    exerciseByKey @EquityStockCashDividendRule (Set.singleton reuters)
+    exerciseByKeyCmd @EquityStockCashDividendRule (Set.singleton reuters)
       EquityStockCashDividend_Lifecycle with
         dividendCid
         entitlementIdLabel = "CashDividend:DAH:USD"
 
   [assetDeposit1Cid, entitlementDeposit1Cid] <- submit alice do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "Alice@AcmeBank:SHARE").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "Alice@AcmeBank:SHARE").id AssetLifecycle_Process with
       depositCid = depositMap ! "Alice@AcmeBank:SHARE:DAH:0:50.0", lifecycleEffectsCid, accountIds = None, consumingDepositCids = []
 
   [assetDeposit2Cid, entitlementDeposit2Cid] <- submit acmeBank do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "AcmeBank@CSD:SHARE").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "AcmeBank@CSD:SHARE").id AssetLifecycle_Process with
       depositCid = depositMap ! "AcmeBank@CSD:SHARE:DAH:0:50.0", lifecycleEffectsCid, accountIds = None, consumingDepositCids = []
 
   dvp1Cid <- submit alice do
-    exerciseByKey @DvpLifecycleRule (maIdMap ! "Charlie&Alice") DvpLifecycle_Process with
+    exerciseByKeyCmd @DvpLifecycleRule (maIdMap ! "Charlie&Alice") DvpLifecycle_Process with
       dvpCid = dvpMap ! "Charlie&Alice:Dvp:0", lifecycleEffectsCid, ctrl = alice
 
   -- Checks
   submitMustFail reuters do
-    exerciseByKey @EquityStockCashDividendRule (Set.singleton reuters)
+    exerciseByKeyCmd @EquityStockCashDividendRule (Set.singleton reuters)
       EquityStockCashDividend_Lifecycle with
         dividendCid
         entitlementIdLabel = "CashDividend:DAH:USD"
@@ -95,51 +98,53 @@ testEquityCashDividend = scenario do
   matchAssetDeposit assetDeposit2Cid csd acmeBank "DAH" 1 50.0
   matchAssetDeposit entitlementDeposit1Cid acmeBank alice "CashDividend:DAH:USD" 0 50.0
   matchAssetDeposit entitlementDeposit2Cid csd acmeBank "CashDividend:DAH:USD" 0 50.0
-  submitMustFail alice do fetch $ depositMap ! "Alice@AcmeBank:DAH:0:50"
-  submitMustFail alice do fetch $ dvpMap ! "Alice&Bob:Dvp:0"
+  let optDeposit = Map.lookup "Alice@AcmeBank:DAH:0:50" depositMap
+  optDeposit === None
+  let optDvp = Map.lookup "Alice&Bob:Dvp:0" dvpMap
+  optDvp === None
 
-  submit alice do
-    dvp1 <- fetch dvp1Cid
-    dvp1.tradeId.version === 1
-    dvp1.deliveries !! 0 === initAsset reuters "DAH" 1 50.0
-    dvp1.deliveries !! 1 === initAsset reuters "CashDividend:DAH:USD" 0 50.0
+  Some dvp1 <- queryContractId alice dvp1Cid
+  dvp1.tradeId.version === 1
+  dvp1.deliveries !! 0 === initAsset reuters "DAH" 1 50.0
+  dvp1.deliveries !! 1 === initAsset reuters "CashDividend:DAH:USD" 0 50.0
 
   -- Process entitlement
-  passToDate $ date 2020 Jan 5
+  setTime (time (date 2020 Jan 5) 0 0 0)
   lifecycleEffectsCid <- submit reuters do
-    exercise entitlementCid Entitlement_Lifecycle
+    exerciseCmd entitlementCid Entitlement_Lifecycle
 
   [cashDeposit1Cid] <- submit alice do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "Alice@AcmeBank:SHARE").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "Alice@AcmeBank:SHARE").id AssetLifecycle_Process with
       depositCid = entitlementDeposit1Cid
       lifecycleEffectsCid
       accountIds = Some [Id with signatories = Set.fromList [alice, acmeBank], label = "Alice@AcmeBank:CASH", version = 0]
       consumingDepositCids = []
   [cashDeposit2Cid] <- submit acmeBank do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "AcmeBank@CSD:SHARE").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "AcmeBank@CSD:SHARE").id AssetLifecycle_Process with
       depositCid = entitlementDeposit2Cid
       lifecycleEffectsCid
       accountIds = Some [Id with signatories = Set.fromList [acmeBank, csd], label = "AcmeBank@CSD:CASH", version = 0]
       consumingDepositCids = []
 
   dvp2Cid <- submit alice do
-    exerciseByKey @DvpLifecycleRule (maIdMap ! "Charlie&Alice") DvpLifecycle_Process with
+    exerciseByKeyCmd @DvpLifecycleRule (maIdMap ! "Charlie&Alice") DvpLifecycle_Process with
       dvpCid = dvp1Cid, lifecycleEffectsCid, ctrl = alice
 
   -- Checks
   matchAssetDeposit cashDeposit1Cid acmeBank alice "USD" 0 20.0
   matchAssetDeposit cashDeposit2Cid csd acmeBank "USD" 0 20.0
-  submitMustFail alice do fetch $ entitlementDeposit1Cid
-  submitMustFail alice do fetch $ dvp1Cid
+  optEntitlement <- queryContractId alice entitlementDeposit1Cid
+  optEntitlement === None
+  optDvp <- queryContractId alice dvp1Cid
+  optDvp === None
 
-  submit alice do
-    dvp2 <- fetch dvp2Cid
-    dvp2.tradeId.version === 2
-    dvp2.payments !! 0 === initAsset reuters "USD" 0 980.0
+  Some dvp2 <- queryContractId alice dvp2Cid
+  dvp2.tradeId.version === 2
+  dvp2.payments !! 0 === initAsset reuters "USD" 0 980.0
 
 
-testEquityStockSplit = scenario do
-  passToDate $ date 2020 Jan 1
+testEquityStockSplit = script do
+  setTime (time (date 2020 Jan 1) 0 0 0)
 
   p@Parties{..} <- partySetup
 
@@ -166,29 +171,30 @@ testEquityStockSplit = scenario do
 
   -- Stock split
   stockSplitCid <- submit reuters do
-    create EquityStockSplit with
+    createCmd EquityStockSplit with
       id = initAssetId reuters "DAH" 0
       exDate = date 2020 Jan 1
       rFactor = 0.5
       observers = Set.fromList $ map (.owner) assetInfo
 
   (_, lifecycleEffectsCid) <- submit reuters do
-    exerciseByKey @EquityStockSplitRule (Set.singleton reuters)
+    exerciseByKeyCmd @EquityStockSplitRule (Set.singleton reuters)
        EquityStockSplit_Lifecycle with stockSplitCid
 
   [depositCid] <- submit alice do
-    exerciseByKey @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
+    exerciseByKeyCmd @AssetLifecycleRule (accountMap ! "Alice@AcmeBank").id AssetLifecycle_Process with
       depositCid = depositMap ! "Alice@AcmeBank:DAH:0:50.0", lifecycleEffectsCid, accountIds = None, consumingDepositCids = []
 
   dvpCid <- submit alice do
-    exerciseByKey @DvpLifecycleRule (maIdMap ! "Charlie&Alice") DvpLifecycle_Process with
+    exerciseByKeyCmd @DvpLifecycleRule (maIdMap ! "Charlie&Alice") DvpLifecycle_Process with
       dvpCid = dvpMap ! "Charlie&Alice:Dvp:0", lifecycleEffectsCid, ctrl = alice
 
   matchAssetDeposit depositCid acmeBank alice "DAH" 1 100.0
-  submitMustFail alice do fetch $ depositMap ! "Alice@AcmeBank:DAH:0:50.0"
-  submitMustFail alice do fetch $ dvpMap ! "Charlie&Alice:Dvp:0"
+  optDeposit <- queryContractId alice (depositMap ! "Alice@AcmeBank:DAH:0:50.0")
+  optDeposit === None
+  optDvp <- queryContractId alice (dvpMap ! "Charlie&Alice:Dvp:0")
+  optDvp === None
 
-  submit alice do
-    dvp <- fetch dvpCid
-    dvp.tradeId.version === 1
-    dvp.deliveries !! 0 === initAsset reuters "DAH" 1 100.0
+  Some dvp <- queryContractId alice dvpCid
+  dvp.tradeId.version === 1
+  dvp.deliveries !! 0 === initAsset reuters "DAH" 1 100.0

--- a/test/src/Test/Finance/Market/Asset.daml
+++ b/test/src/Test/Finance/Market/Asset.daml
@@ -8,6 +8,7 @@ import DA.Action
 import DA.Next.Map as Map
 import DA.Next.Set as Set
 import DA.Text
+import Daml.Script
 
 import DA.Finance.Asset
 import DA.Finance.Asset.Settlement
@@ -78,10 +79,10 @@ template AssetMarketItemProposal
           create AssetSettlementRule with ..
           create AssetLifecycleRule with ..
           deposits <- mapA (\asset -> (,) (assetLabel asset) <$> create AssetDeposit with ..) assets
-          
+
           return AssetMarketItem with account = label_account, deposits
 
-assetSetup : Test m => Parties -> TrustModel -> [AssetInfo] -> m AssetMarket
+assetSetup : Parties -> TrustModel -> [AssetInfo] -> Script AssetMarket
 assetSetup p@Parties{..} trustModel assetInfo = do
 
   -- Init signatories according to trust model
@@ -100,8 +101,8 @@ assetSetup p@Parties{..} trustModel assetInfo = do
         let assets = map (\(label, quantity) -> initAsset reuters label 0 quantity) assetData
         let ctrls = Set.fromList $ map (.owner) assetInfo
 
-        propCid <- submitCreate (setFst sigs) AssetMarketItemProposal with proposer = (setFst sigs), ..
-        add market <$> submitExercise (setSndOrFirst sigs) propCid Accept
+        propCid <- submit (setFst sigs) $ createCmd AssetMarketItemProposal with proposer = (setFst sigs), ..
+        add market <$> submit (setSndOrFirst sigs) (exerciseCmd propCid Accept)
 
   let empty = AssetMarket with accountMap = Map.empty, depositMap = Map.empty
   foldrA process empty assetInfo

--- a/test/src/Test/Finance/Market/Dvp.daml
+++ b/test/src/Test/Finance/Market/Dvp.daml
@@ -8,6 +8,7 @@ import DA.Action
 import DA.List
 import DA.Next.Map as Map
 import DA.Next.Set as Set
+import Daml.Script
 
 import DA.Finance.Trade.Dvp
 import DA.Finance.Trade.Dvp.Lifecycle
@@ -22,7 +23,7 @@ data DvpMarket = DvpMarket
   with
     maIdMap : Map Text Id
     dvpMap : Map Text (ContractId Dvp)
-    
+
 data DvpMarketItem = DvpMarketItem
   with
     maId : (Text, Id)
@@ -80,10 +81,10 @@ template DvpMarketItemProposal
           create DvpInstructionRule with masterAgreement
           create DvpSettlementRule with masterAgreement
           dvps <- mapA (\dvp -> (,)  (label <> ":" <> dvp.tradeId.label) <$> create dvp) dvps
-          
+
           return DvpMarketItem with ..
 
-dvpSetup : Test m => Parties -> TrustModel -> [TradeInfo] -> m DvpMarket
+dvpSetup : Parties -> TrustModel -> [TradeInfo] -> Script DvpMarket
 dvpSetup p@Parties{..} trustModel tradeInfo = do
 
   -- Init signatories according to trust model
@@ -110,8 +111,8 @@ dvpSetup p@Parties{..} trustModel tradeInfo = do
                         )
                     dvpInfo
 
-        propCid <- submitCreate (setFst sigs) DvpMarketItemProposal with proposer = (setFst sigs), ..
-        add market <$> submitExercise (setSndOrFirst sigs) propCid Accept
+        propCid <- submit (setFst sigs) $ createCmd DvpMarketItemProposal with proposer = (setFst sigs), ..
+        add market <$> submit (setSndOrFirst sigs) (exerciseCmd propCid Accept)
 
   let empty = DvpMarket with maIdMap = Map.empty, dvpMap = Map.empty
   foldrA process empty tradeInfo

--- a/test/src/Test/Finance/Market/Instrument.daml
+++ b/test/src/Test/Finance/Market/Instrument.daml
@@ -6,6 +6,7 @@ module Test.Finance.Market.Instrument where
 
 import DA.Next.Map as Map
 import DA.Next.Set as Set
+import Daml.Script
 
 import DA.Finance.Instrument.Equity.Option
 import DA.Finance.Instrument.Equity.Option.Lifecycle
@@ -37,27 +38,27 @@ data OptionInfo = OptionInfo
     maturity : Date
     settlementType : SettlementType
 
-instrumentSetup : Test m => Party -> Set Party -> [StockInfo] -> [OptionInfo] -> m InstrumentMarket
+instrumentSetup : Party -> Set Party -> [StockInfo] -> [OptionInfo] -> Script InstrumentMarket
 instrumentSetup provider observers stockInfo optionInfo = do
   -- Process a single stock
   let processStock StockInfo{..} = do
         let ccy = initAssetId provider ccyLabel 0
         let id = initAssetId provider stockLabel 0
-        (,) stockLabel <$> submitCreate provider EquityStock with observers = Set.empty, ..
+        (,) stockLabel <$> submit provider (createCmd EquityStock with observers = Set.empty, ..)
 
   -- Process a single option
   let processOption OptionInfo{..} = do
         let underlyingId = initAssetId provider undLabel 0
         let id = initAssetId provider optionLabel 0
-        (,) optionLabel <$> submitCreate provider EquityOption with ..
+        (,) optionLabel <$> submit provider (createCmd EquityOption with ..)
 
   let signatories = Set.singleton provider
-  submitCreate provider EquityStockCashDividendRule with signatories
-  submitCreate provider EquityStockSplitRule with signatories
+  submit provider $ createCmd EquityStockCashDividendRule with signatories
+  submit provider $ createCmd EquityStockSplitRule with signatories
   stockMap <- Map.fromList <$> mapA processStock stockInfo
 
-  submitCreate provider EquityOptionExerciseRule with signatories
-  submitCreate provider EquityOptionStockSplitRule with signatories
+  submit provider $ createCmd EquityOptionExerciseRule with signatories
+  submit provider $ createCmd EquityOptionStockSplitRule with signatories
   optionMap <- Map.fromList <$> mapA processOption optionInfo
 
   return InstrumentMarket with ..

--- a/test/src/Test/Finance/Market/Party.daml
+++ b/test/src/Test/Finance/Market/Party.daml
@@ -4,6 +4,8 @@
 daml 1.2
 module Test.Finance.Market.Party where
 
+import Daml.Script
+
 data Parties = Parties
   with
     acmeBank : Party
@@ -16,16 +18,16 @@ data Parties = Parties
     csd : Party
     reuters : Party
 
-partySetup : Scenario Parties
-partySetup = scenario do
-  acmeBank <- getParty "AcmeBank"
-  gencoBank <- getParty "GencoBank"
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
-  charlie <- getParty "Charlie"
-  agent <- getParty "Agent"
-  cb <- getParty "CB"
-  csd <- getParty "CSD"
-  reuters <- getParty "Reuters"
+partySetup : Script Parties
+partySetup = script do
+  acmeBank <- allocateParty "AcmeBank"
+  gencoBank <- allocateParty "GencoBank"
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
+  charlie <- allocateParty "Charlie"
+  agent <- allocateParty "Agent"
+  cb <- allocateParty "CB"
+  csd <- allocateParty "CSD"
+  reuters <- allocateParty "Reuters"
 
   pure $ Parties with ..

--- a/test/src/Test/Finance/Trade/Dvp.daml
+++ b/test/src/Test/Finance/Trade/Dvp.daml
@@ -7,6 +7,7 @@ module Test.Finance.Trade.Dvp where
 import DA.Assert
 import DA.List
 import DA.Next.Set as Set
+import Daml.Script
 
 import DA.Finance.Trade.Dvp.Settlement
 import DA.Finance.Trade.SettlementInstruction
@@ -19,17 +20,17 @@ import Test.Finance.Types
 import Test.Finance.Utils
 
 -- | Allocate to instruction.
-submitAllocate : AssetMarket -> ContractId SettlementInstruction -> Party -> Text -> Scenario (ContractId SettlementInstruction)
+submitAllocate : AssetMarket -> ContractId SettlementInstruction -> Party -> Text -> Script (ContractId SettlementInstruction)
 submitAllocate AssetMarket{..} instrCid owner deposit =
   submit owner do
-    exercise instrCid SettlementInstruction_AllocateNext with depositCid = (depositMap ! deposit), ctrl = owner
+    exerciseCmd instrCid SettlementInstruction_AllocateNext with depositCid = (depositMap ! deposit), ctrl = owner
 
 -- | Test direct (i.e. a single step) Dvp settlement, where both counterparties
 -- have an account with the same provider.
-testDvpSettlementDirect : Parties -> TrustModel -> TrustModel -> Scenario DvpSettlement_Process_Result
+testDvpSettlementDirect : Parties -> TrustModel -> TrustModel -> Script DvpSettlement_Process_Result
 testDvpSettlementDirect p@Parties{..} assetTrustModel dvpTrustModel = do
   -- Assets & Dvp
-  let assetInfo = 
+  let assetInfo =
         [ AssetInfo with provider = acmeBank, owner = alice, accountType = None, assetData = [("USD", 1000.0)]
         , AssetInfo with provider = acmeBank, owner = bob, accountType = None, assetData = [("DAH", 50.0)]
         ]
@@ -50,7 +51,7 @@ testDvpSettlementDirect p@Parties{..} assetTrustModel dvpTrustModel = do
 
   -- Instruct Dvp
   result <- submit alice do
-              exerciseByKey @DvpInstructionRule (maIdMap ! "Alice&Bob") DvpInstruction_Process with
+              exerciseByKeyCmd @DvpInstructionRule (maIdMap ! "Alice&Bob") DvpInstruction_Process with
                 dvpCid = dvpMap ! "Alice&Bob:Dvp:0"
                 paymentSteps = [[ initSettlementDetails accountMap acmeBank alice bob ]]
                 deliverySteps = [[ initSettlementDetails accountMap acmeBank bob alice ]]
@@ -62,7 +63,7 @@ testDvpSettlementDirect p@Parties{..} assetTrustModel dvpTrustModel = do
 
   -- Settle Dvp
   result <- submit bob do
-              exerciseByKey @DvpSettlementRule (maIdMap ! "Alice&Bob") DvpSettlement_Process with
+              exerciseByKeyCmd @DvpSettlementRule (maIdMap ! "Alice&Bob") DvpSettlement_Process with
                 dvpCid = result.dvpCid
                 paymentInstructionCids = [paymentInstructionCid]
                 deliveryInstructionCids = [deliveryInstructionCid]
@@ -72,66 +73,59 @@ testDvpSettlementDirect p@Parties{..} assetTrustModel dvpTrustModel = do
   matchAssetDeposit (head $ head result.paymentDepositCids) acmeBank bob "USD" 0 1000.0
   matchAssetDeposit (head $ head result.deliveryDepositCids) acmeBank alice "DAH" 0 50.0
 
-  submitMustFail alice do fetch (depositMap ! "Alice@AcmeBank:USD:0:1000.0")
-  submitMustFail bob do fetch (depositMap ! "Bob@AcmeBank:DAH:0:50.0")
+  optDeposit <- queryContractId alice (depositMap ! "Alice@AcmeBank:USD:0:1000.0")
+  optDeposit === None
+  optDeposit <- queryContractId bob (depositMap ! "Bob@AcmeBank:DAH:0:50.0")
+  optDeposit === None
 
   return result
 
-testDvpSettlementDirect_Bilateral = scenario do
+testDvpSettlementDirect_Bilateral = script do
   p@Parties{..} <- partySetup
   result <- testDvpSettlementDirect p TrustModel_Bilateral TrustModel_Bilateral
 
-  submit alice do
-    c <- fetch result.dvpCid
-    c.masterAgreement.id.signatories === Set.fromList [alice, bob]
+  Some c <- queryContractId alice result.dvpCid
+  c.masterAgreement.id.signatories === Set.fromList [alice, bob]
 
-  submit bob do
-    c <- fetch $ head $ head result.paymentDepositCids
-    c.account.id.signatories === Set.fromList [acmeBank, bob]
+  Some c <- queryContractId bob (head $ head result.paymentDepositCids)
+  c.account.id.signatories === Set.fromList [acmeBank, bob]
 
-  submit alice do
-    c <- fetch $ head $ head result.deliveryDepositCids
-    c.account.id.signatories === Set.fromList [acmeBank, alice]
+  Some c <- queryContractId alice (head $ head result.deliveryDepositCids)
+  c.account.id.signatories === Set.fromList [acmeBank, alice]
 
-testDvpSettlementDirect_Unilateral = scenario do
+testDvpSettlementDirect_Unilateral = script do
   p@Parties{..} <- partySetup
   result <- testDvpSettlementDirect p TrustModel_Unilateral TrustModel_Bilateral
 
-  submit alice do
-    c <- fetch result.dvpCid
-    c.masterAgreement.id.signatories === Set.fromList [alice, bob]
+  Some c <- queryContractId alice result.dvpCid
+  c.masterAgreement.id.signatories === Set.fromList [alice, bob]
 
-  submit bob do
-    c <- fetch $ head $ head result.paymentDepositCids
-    c.account.id.signatories === Set.fromList [acmeBank]
+  Some c <- queryContractId bob (head $ head result.paymentDepositCids)
+  c.account.id.signatories === Set.fromList [acmeBank]
 
-  submit alice do
-    c <- fetch $ head $ head result.deliveryDepositCids
-    c.account.id.signatories === Set.fromList [acmeBank]
+  Some c <- queryContractId alice (head $ head result.deliveryDepositCids)
+  c.account.id.signatories === Set.fromList [acmeBank]
 
-testDvpSettlementDirect_Agent = scenario do
+testDvpSettlementDirect_Agent = script do
   p@Parties{..} <- partySetup
   result <- testDvpSettlementDirect p TrustModel_Bilateral TrustModel_Agent
 
-  submit alice do
-    c <- fetch result.dvpCid
-    c.masterAgreement.id.signatories === Set.fromList [agent]
+  Some c <- queryContractId alice result.dvpCid
+  c.masterAgreement.id.signatories === Set.fromList [agent]
 
-  submit bob do
-    c <- fetch $ head $ head result.paymentDepositCids
-    c.account.id.signatories === Set.fromList [acmeBank, bob]
+  Some c <- queryContractId bob (head $ head result.paymentDepositCids)
+  c.account.id.signatories === Set.fromList [acmeBank, bob]
 
-  submit alice do
-    c <- fetch $ head $ head result.deliveryDepositCids
-    c.account.id.signatories === Set.fromList [acmeBank, alice]
+  Some c <- queryContractId alice (head $ head result.deliveryDepositCids)
+  c.account.id.signatories === Set.fromList [acmeBank, alice]
 
 
 -- | Test Dvp settlement up and down the hierarchy, i.e. the counterparties
 -- do not have an account with the same provider.
-testDvpSettlementChain : Parties -> TrustModel -> TrustModel -> Scenario ()
+testDvpSettlementChain : Parties -> TrustModel -> TrustModel -> Script ()
 testDvpSettlementChain p@Parties{..} assetTrustModel dvpTrustModel = do
   -- Assets & Dvp
-  let assetInfo = 
+  let assetInfo =
         [ AssetInfo with provider = gencoBank, owner = charlie, accountType = None, assetData = [("USD", 1000.0)]
         , AssetInfo with provider = cb, owner = gencoBank, accountType = None, assetData = [("USD", 1000.0)]
         , AssetInfo with provider = cb, owner = acmeBank, accountType = None, assetData = [] -- Required for trade relationship
@@ -158,7 +152,7 @@ testDvpSettlementChain p@Parties{..} assetTrustModel dvpTrustModel = do
 
   -- Instruct Dvp
   result <- submit charlie do
-              exerciseByKey @DvpInstructionRule (maIdMap ! "Charlie&Alice") DvpInstruction_Process with
+              exerciseByKeyCmd @DvpInstructionRule (maIdMap ! "Charlie&Alice") DvpInstruction_Process with
                 dvpCid = dvpMap ! "Charlie&Alice:Dvp:0"
                 paymentSteps =
                   [[ initSettlementDetails accountMap gencoBank charlie gencoBank
@@ -185,7 +179,7 @@ testDvpSettlementChain p@Parties{..} assetTrustModel dvpTrustModel = do
 
   -- Settle Dvp
   result <- submit alice do
-              exerciseByKey @DvpSettlementRule (maIdMap ! "Charlie&Alice") DvpSettlement_Process with
+              exerciseByKeyCmd @DvpSettlementRule (maIdMap ! "Charlie&Alice") DvpSettlement_Process with
                 dvpCid = result.dvpCid
                 paymentInstructionCids = [paymentInstructionCid]
                 deliveryInstructionCids = [deliveryInstructionCid]
@@ -199,21 +193,27 @@ testDvpSettlementChain p@Parties{..} assetTrustModel dvpTrustModel = do
   matchAssetDeposit (result.deliveryDepositCids !! 0 !! 1) csd gencoBank "DAH" 0 50.0
   matchAssetDeposit (result.deliveryDepositCids !! 0 !! 2) gencoBank charlie "DAH" 0 50.0
 
-  submitMustFail charlie do fetch (depositMap ! "Charlie@GencoBank:USD:0:1000.0")
-  submitMustFail charlie do fetch (depositMap ! "GencoBank@CB:USD:0:1000.0")
-  submitMustFail charlie do fetch (depositMap ! "AcmeBank@AcmeBank:USD:0:1000.0")
-  submitMustFail alice do fetch (depositMap ! "Alice@AcmeBank:DAH:0:50.0")
-  submitMustFail alice do fetch (depositMap ! "AcmeBank@CSD:DAH:0:50.0")
-  submitMustFail alice do fetch (depositMap ! "GencoBank@GencoBank:DAH:0:50.0")
+  optDeposit <- queryContractId charlie (depositMap ! "Charlie@GencoBank:USD:0:1000.0")
+  optDeposit === None
+  optDeposit <- queryContractId charlie (depositMap ! "GencoBank@CB:USD:0:1000.0")
+  optDeposit === None
+  optDeposit <- queryContractId charlie (depositMap ! "AcmeBank@AcmeBank:USD:0:1000.0")
+  optDeposit === None
+  optDeposit <- queryContractId alice (depositMap ! "Alice@AcmeBank:DAH:0:50.0")
+  optDeposit === None
+  optDeposit <- queryContractId alice (depositMap ! "AcmeBank@CSD:DAH:0:50.0")
+  optDeposit === None
+  optDeposit <- queryContractId alice (depositMap ! "GencoBank@GencoBank:DAH:0:50.0")
+  optDeposit === None
 
-testDvpSettlementChain_Bilateral = scenario do
+testDvpSettlementChain_Bilateral = script do
   p@Parties{..} <- partySetup
   testDvpSettlementChain p TrustModel_Bilateral TrustModel_Bilateral
 
-testDvpSettlementChain_Unilateral = scenario do
+testDvpSettlementChain_Unilateral = script do
   p@Parties{..} <- partySetup
   testDvpSettlementChain p TrustModel_Unilateral TrustModel_Bilateral
 
-testDvpSettlementChain_Agent = scenario do
+testDvpSettlementChain_Agent = script do
   p@Parties{..} <- partySetup
   testDvpSettlementChain p TrustModel_Agent TrustModel_Agent

--- a/test/src/Test/Finance/Utils.daml
+++ b/test/src/Test/Finance/Utils.daml
@@ -13,27 +13,11 @@ import DA.List
 import DA.Next.Map as Map
 import DA.Next.Set as Set
 import DA.Optional
-import Prelude as Scenario
-import Daml.Script as Script
 
 import DA.Finance.Trade.Dvp
 import DA.Finance.Trade.SettlementInstruction
 import DA.Finance.Types
 import DA.Finance.Utils
-
--- | A type class that allows to run a function in
--- either a Scenario or Script context.
-class Action m => Test m where
-  submitCreate : Template t => Party -> t -> m (ContractId t)
-  submitExercise : (Template t, Choice t c r ) => Party -> ContractId t -> c -> m r
-
-instance Test Scenario where
-  submitCreate party c = Scenario.submit party do create c
-  submitExercise party cid choice = Scenario.submit party do exercise cid choice
-
-instance Test Script where
-  submitCreate party c = Script.submit party do createCmd c
-  submitExercise party cid choice = Script.submit party do exerciseCmd cid choice
 
 -- | Get first element of Set.
 setFst : MapKey a => Set a -> a
@@ -57,7 +41,7 @@ mapValues = map snd . Map.toList
 infixl 9 !
 -- | Find the value at a key. Calls error when the element can not be found.
 (!) : (Show k, MapKey k) => Map k v -> k -> v
-(!) m x = fromSomeNote ("key " <> show x <> " does not exist") $ Map.lookup x m
+(!) m x = fromSomeNote ("key " <> show x <> " does not exist, " <> show (map fst $ Map.toList m)) $ Map.lookup x m
 
 -- | Init asset id.
 initAssetId : Party -> Text -> Int -> Id
@@ -93,7 +77,7 @@ template DvpInstructionRule
     observer masterAgreement.party1, masterAgreement.party2
 
     key masterAgreement.id : Id
-    maintainer key.signatories 
+    maintainer key.signatories
 
     nonconsuming choice DvpInstruction_Process: DvpInstruction_Process_Result
       with
@@ -117,4 +101,3 @@ template DvpInstructionRule
         deliveryInstructionCids <- mapA work $ zipChecked dvp.deliveries deliverySteps
 
         return DvpInstruction_Process_Result with ..
-    

--- a/test/src/Test/StartupScript.daml
+++ b/test/src/Test/StartupScript.daml
@@ -18,7 +18,6 @@ import Test.Finance.Market.Dvp
 import Test.Finance.Market.Instrument
 import Test.Finance.Market.Party
 import Test.Finance.Types hiding (CASH)
-import Test.Finance.Utils
 
 -- | A script that can be used to set up a market.
 startup : Parties -> Script (InstrumentMarket, AssetMarket, DvpMarket)
@@ -41,7 +40,7 @@ startup p@Parties{..} = do
   let observers = Set.fromList [alice, charlie, bob, gencoBank, acmeBank, csd]
   im@InstrumentMarket{..} <- instrumentSetup reuters observers stockInfo optionInfo
 
-  let assetInfo = 
+  let assetInfo =
         [ AssetInfo with provider = gencoBank, owner = charlie, accountType = None, assetData = [("USD", 1500.0), ("Option", 3.0)]
         , AssetInfo with provider = cb, owner = gencoBank, accountType = None, assetData = [("USD", 1500.0)]
         , AssetInfo with provider = cb, owner = acmeBank, accountType = None, assetData = [] -- Required for trade relationship
@@ -73,6 +72,6 @@ startup p@Parties{..} = do
         ]
   dm@DvpMarket{..} <- dvpSetup p TrustModel_Bilateral tradeInfo
 
-  mapA_ (\sig -> submitCreate sig AllocationRule with sig) $ dedup $ map (.owner) assetInfo
+  mapA_ (\sig -> submit sig $ createCmd AllocationRule with sig) $ dedup $ map (.owner) assetInfo
 
   return (im, am, dm)

--- a/trigger/daml.yaml
+++ b/trigger/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.5.0-snapshot.20200902.5118.0.2b3cf1b3
+sdk-version: 1.5.0
 name: finlib-trigger
 version: 2.0.0
 source: src

--- a/trigger/daml.yaml
+++ b/trigger/daml.yaml
@@ -1,12 +1,13 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.2.0
+sdk-version: 1.5.0-snapshot.20200902.5118.0.2b3cf1b3
 name: finlib-trigger
 version: 2.0.0
 source: src
 dependencies:
 - daml-prim
 - daml-stdlib
+- daml-script
 - daml-trigger
 - ../model/.daml/dist/finlib-2.0.0.dar


### PR DESCRIPTION
Now that DAML Script runs in DAML Studio, we are starting to migrate
our examples over to DAML Script before we deprecate scenarios.

Most of the stuff in this PR is very straightforward. `fetch` is not a
ledger API command so we use `queryContractId` instead (which is
equivalent to the ACS endpoint + client-side filtering).

I don’t know your version policy but you might want to hold off on
merging this until 1.5.0 is released.