### PR TITLE
Remove deprecated modules, bump sdk.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   daml:
     docker:
-      - image: digitalasset/daml-sdk:1.7.0
+      - image: digitalasset/daml-sdk:1.12.0
     steps:
       - checkout
       - setup_remote_docker

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ DIRS=("model"
 
 function cleanDars {
   for dr in ${DIRS[@]}
-  do 
+  do
     rm -f $dr/.dist
   done
 }
@@ -20,6 +20,18 @@ function buildDars {
     echo "building dar in $dr"
     cd $dr
     daml build
+    cd ..
+  done
+}
+
+function testDars {
+  for dr in ${DIRS[@]}
+  do
+    echo "running tests in $dr"
+    cd $dr
+    hyphens=${1:+'--'}
+    TESTS=$(daml test --color ${hyphens}$1)
+    if [ -z "$TESTS" ]; then echo -e "${RED}No tests found${NC}"; else echo "$TESTS"; fi
     cd ..
   done
 }
@@ -49,10 +61,13 @@ case $1 in
     cleanDars
     buildDars
     ;;
+  test-dars)
+     testDars $2;;
   *)
     echo "builder <command>"
     echo "  commands are:"
     echo "    build-dars - builds the dars"
+    echo "    test-dars - run 'daml test' for each dar, next param is passed as option"
     echo "    update-version <version> - changes the sdk version number"
     ;;
 esac

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.7.0
+sdk-version: 1.12.0

--- a/model/daml.yaml
+++ b/model/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.7.0
+sdk-version: 1.12.0
 name: finlib
 version: 2.0.0
 source: src

--- a/model/src/DA/Finance/Asset.daml
+++ b/model/src/DA/Finance/Asset.daml
@@ -5,7 +5,7 @@ module DA.Finance.Asset where
 
 import DA.Action
 import DA.Assert
-import DA.Next.Set
+import DA.Set
 
 import DA.Finance.Types
 import DA.Finance.Utils

--- a/model/src/DA/Finance/Asset/Lifecycle.daml
+++ b/model/src/DA/Finance/Asset/Lifecycle.daml
@@ -2,7 +2,7 @@ module DA.Finance.Asset.Lifecycle where
 
 import DA.Assert
 import DA.Foldable (mapA_)
-import DA.Next.Set as Set
+import DA.Set as Set
 
 import DA.Finance.Asset
 import DA.Finance.Asset.Settlement

--- a/model/src/DA/Finance/Asset/Settlement.daml
+++ b/model/src/DA/Finance/Asset/Settlement.daml
@@ -1,7 +1,7 @@
 module DA.Finance.Asset.Settlement where
 
 import DA.Assert
-import DA.Next.Set as Set
+import DA.Set as Set
 
 import DA.Finance.Asset
 import DA.Finance.Types

--- a/model/src/DA/Finance/Instrument/Entitlement.daml
+++ b/model/src/DA/Finance/Instrument/Entitlement.daml
@@ -3,7 +3,7 @@
 
 module DA.Finance.Instrument.Entitlement where
 
-import DA.Next.Set
+import DA.Set
 
 import DA.Finance.Asset.Lifecycle
 import DA.Finance.Types

--- a/model/src/DA/Finance/Instrument/Equity/ACBRC.daml
+++ b/model/src/DA/Finance/Instrument/Equity/ACBRC.daml
@@ -1,6 +1,6 @@
 module DA.Finance.Instrument.Equity.ACBRC where
 
-import DA.Next.Set
+import DA.Set
 import DA.Finance.Types
 
 template ACBRC

--- a/model/src/DA/Finance/Instrument/Equity/ACBRC/Lifecycle.daml
+++ b/model/src/DA/Finance/Instrument/Equity/ACBRC/Lifecycle.daml
@@ -5,7 +5,7 @@ module DA.Finance.Instrument.Equity.ACBRC.Lifecycle where
 
 import DA.Assert
 import DA.List
-import DA.Next.Set
+import DA.Set
 
 import DA.Finance.Asset.Lifecycle
 import DA.Finance.Instrument.Equity.ACBRC

--- a/model/src/DA/Finance/Instrument/Equity/CashDividend.daml
+++ b/model/src/DA/Finance/Instrument/Equity/CashDividend.daml
@@ -3,7 +3,7 @@
 
 module DA.Finance.Instrument.Equity.CashDividend where
 
-import DA.Next.Set
+import DA.Set
 
 import DA.Finance.Types
 

--- a/model/src/DA/Finance/Instrument/Equity/Option.daml
+++ b/model/src/DA/Finance/Instrument/Equity/Option.daml
@@ -3,7 +3,7 @@
 
 module DA.Finance.Instrument.Equity.Option where
 
-import DA.Next.Set
+import DA.Set
 
 import DA.Finance.Types
 

--- a/model/src/DA/Finance/Instrument/Equity/Option/Lifecycle.daml
+++ b/model/src/DA/Finance/Instrument/Equity/Option/Lifecycle.daml
@@ -5,7 +5,7 @@ module DA.Finance.Instrument.Equity.Option.Lifecycle where
 
 import DA.Action
 import DA.Assert
-import DA.Next.Set
+import DA.Set
 import DA.Optional.Total
 
 import DA.Finance.Asset.Lifecycle

--- a/model/src/DA/Finance/Instrument/Equity/Stock.daml
+++ b/model/src/DA/Finance/Instrument/Equity/Stock.daml
@@ -3,7 +3,7 @@
 
 module DA.Finance.Instrument.Equity.Stock where
 
-import DA.Next.Set
+import DA.Set
 
 import DA.Finance.Types
 

--- a/model/src/DA/Finance/Instrument/Equity/Stock/Lifecycle.daml
+++ b/model/src/DA/Finance/Instrument/Equity/Stock/Lifecycle.daml
@@ -3,7 +3,7 @@
 
 module DA.Finance.Instrument.Equity.Stock.Lifecycle where
 
-import DA.Next.Set
+import DA.Set
 
 import DA.Finance.Asset.Lifecycle
 import DA.Finance.Instrument.Entitlement

--- a/model/src/DA/Finance/Instrument/Equity/StockSplit.daml
+++ b/model/src/DA/Finance/Instrument/Equity/StockSplit.daml
@@ -3,7 +3,7 @@
 
 module DA.Finance.Instrument.Equity.StockSplit where
 
-import DA.Next.Set
+import DA.Set
 
 import DA.Finance.Types
 

--- a/model/src/DA/Finance/Instrument/FX/Currency.daml
+++ b/model/src/DA/Finance/Instrument/FX/Currency.daml
@@ -3,7 +3,7 @@
 
 module DA.Finance.Instrument.FX.Currency where
 
-import DA.Next.Set
+import DA.Set
 
 import DA.Finance.Types
 

--- a/model/src/DA/Finance/Instrument/FixedIncome/FixedRateBond.daml
+++ b/model/src/DA/Finance/Instrument/FixedIncome/FixedRateBond.daml
@@ -3,7 +3,7 @@
 
 module DA.Finance.Instrument.FixedIncome.FixedRateBond where
 
-import DA.Next.Set
+import DA.Set
 import DA.Finance.Types
 
 template FixedRateBond

--- a/model/src/DA/Finance/Instrument/FixedIncome/FixedRateBond/Lifecycle.daml
+++ b/model/src/DA/Finance/Instrument/FixedIncome/FixedRateBond/Lifecycle.daml
@@ -4,7 +4,7 @@
 module DA.Finance.Instrument.FixedIncome.FixedRateBond.Lifecycle where
 
 import DA.List
-import DA.Next.Set
+import DA.Set
 
 import DA.Finance.Asset.Lifecycle
 import DA.Finance.Instrument.FixedIncome.FixedRateBond

--- a/model/src/DA/Finance/RefData/Fixing.daml
+++ b/model/src/DA/Finance/RefData/Fixing.daml
@@ -3,7 +3,7 @@
 
 module DA.Finance.RefData.Fixing where
 
-import DA.Next.Set
+import DA.Set
 import DA.Finance.Types
 
 template Fixing

--- a/model/src/DA/Finance/Trade/Dvp.daml
+++ b/model/src/DA/Finance/Trade/Dvp.daml
@@ -7,7 +7,7 @@ module DA.Finance.Trade.Dvp
   )
   where
 
-import DA.Next.Set hiding (null)
+import DA.Set hiding (null)
 
 import DA.Finance.Trade.Types
 import DA.Finance.Types

--- a/model/src/DA/Finance/Trade/Dvp/Lifecycle.daml
+++ b/model/src/DA/Finance/Trade/Dvp/Lifecycle.daml
@@ -58,8 +58,8 @@ apply _ asset = ([asset], [])
 net : [Asset] -> [Asset] -> ([Asset], [Asset])
 net payments deliveries =
   let paymentsNetted =
-        filter (\p -> p.quantity > 0.0)
-        $ map (\p -> p with quantity = p.quantity - foldMap (.quantity) (filter (\d -> d.id == p.id) deliveries))
+        filter (\Asset{..} -> quantity > 0.0)
+        $ map (\p@Asset{..} -> p with quantity = quantity - foldMap (.quantity) (filter (\Asset{..} -> id == p.id) deliveries))
         payments
 
       deliveriesNetted =

--- a/model/src/DA/Finance/Trade/SettlementInstruction.daml
+++ b/model/src/DA/Finance/Trade/SettlementInstruction.daml
@@ -6,7 +6,7 @@ module DA.Finance.Trade.SettlementInstruction where
 import DA.Assert
 import DA.Either
 import DA.List
-import DA.Next.Set
+import DA.Set hiding (null)
 import DA.Optional hiding (fromSomeNote)
 import DA.Optional.Total (fromSomeNote)
 
@@ -47,14 +47,14 @@ template SettlementInstruction
     signatory union masterAgreement.id.signatories $ fromList sendersDone
     observer insert masterAgreement.party1 $ insert masterAgreement.party2
       $ union observers $ fromList sendersPending
-    ensure length steps > 0 && asset.quantity > 0.0
+    ensure not (null steps) && asset.quantity > 0.0
       && all (\(s1,s2) -> s1.receiverAccount.owner == s2.senderAccount.owner) (zip steps $ tail steps)
 
     key (masterAgreement.id, tradeId, asset.id) : (Id, Id, Id)
     maintainer key._1.signatories
 
     let (sendersDone, sendersPending) = partitionEithers $
-          map (\x -> if isSome x.depositCid then Left x.senderAccount.owner else Right x.senderAccount.owner) steps
+          map (\SettlementDetails{..} -> if isSome depositCid then Left senderAccount.owner else Right senderAccount.owner) steps
 
     choice SettlementInstruction_AllocateNext : ContractId SettlementInstruction
       -- ^ Allocates an asset deposit to the next step of the settlement instruction.

--- a/model/src/DA/Finance/Tutorial.daml
+++ b/model/src/DA/Finance/Tutorial.daml
@@ -3,7 +3,7 @@ module DA.Finance.Tutorial where
 
 import Daml.Script
 
-import DA.Next.Set
+import DA.Set
 import DA.Finance.Asset
 import DA.Finance.Asset.Settlement
 import DA.Finance.Types
@@ -173,7 +173,7 @@ In the above transaction GencoBank ends up with a deposit at AcmeBank to offset 
 
 -}
 
-scneario5 = do
+script5 = do
   cb <- allocateParty "CentralBank"
   acme <- allocateParty "AcmeBank"
   genco <- allocateParty "GencoBank"

--- a/model/src/DA/Finance/Types.daml
+++ b/model/src/DA/Finance/Types.daml
@@ -3,7 +3,7 @@
 
 module DA.Finance.Types where
 
-import DA.Next.Set as Set
+import DA.Set as Set
 import DA.Text
 import Prelude hiding (id)
 

--- a/model/src/DA/Finance/Utils.daml
+++ b/model/src/DA/Finance/Utils.daml
@@ -5,10 +5,6 @@ module DA.Finance.Utils where
 
 import DA.Date
 import DA.List as List
--- import DA.Map
--- import DA.Set as Set
--- import DA.Text as Text
-
 import DA.Finance.Types
 
 instance Semigroup Decimal where

--- a/model/src/DA/Finance/Utils.daml
+++ b/model/src/DA/Finance/Utils.daml
@@ -5,9 +5,9 @@ module DA.Finance.Utils where
 
 import DA.Date
 import DA.List as List
-import DA.Next.Map
-import DA.Next.Set as Set
-import DA.Text as Text
+-- import DA.Map
+-- import DA.Set as Set
+-- import DA.Text as Text
 
 import DA.Finance.Types
 
@@ -17,21 +17,6 @@ instance Semigroup Decimal where
 instance Monoid Decimal where
   mempty = 0.0
 
-instance MapKey a => MapKey (Set a) where
-  keyToText s = "Set(" <> Text.intercalate ";" (map keyToText $ Set.toList s) <> ")"
-  keyFromText = Set.fromList . map keyFromText . splitOn ";" . Text.dropPrefix "Set(" . Text.dropSuffix ")"
-
-instance MapKey Id where
-  keyToText Id{..} = keyToText signatories <> "-" <> label <> "-" <> keyToText version
-  keyFromText text =
-    let [signatoriesText, label, versionText] = splitOn "-" text
-        signatories = keyFromText signatoriesText
-        version = keyFromText versionText
-    in Id with ..
-
-instance (MapKey a, MapKey b) => MapKey (a, b) where
-  keyToText (x, y) = "Tuple(" <> keyToText x <> "," <> keyToText y <> ")"
-  keyFromText = (\[x, y] -> (keyFromText x, keyFromText y)) . splitOn "," . Text.dropPrefix "Tuple(" . Text.dropSuffix ")"
 
 -- | Fetches a contract, archives it and returns its value.
 fetchAndArchive : Template a => ContractId a -> Update a
@@ -60,7 +45,7 @@ zipChecked xs ys
 
 -- | Checks if array is not empty.
 notNull : [a] -> Bool
-notNull xs = not $ List.null xs
+notNull = not . List.null
 
 -- | Update n-th element in a list
 updateListElement : Int -> (a -> a) -> [a] -> [a]
@@ -71,4 +56,4 @@ updateListElement n f xs = zipWith impl xs [0..(List.length xs - 1)]
 
 -- | Increase id version.
 increaseVersion : Id -> Id
-increaseVersion id = id with version = id.version + 1
+increaseVersion id@Id{..} = id with version = version + 1

--- a/test/daml.yaml
+++ b/test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.7.0
+sdk-version: 1.12.0
 name: finlib-test
 version: 2.0.0
 source: src

--- a/test/src/Test/Finance/Asset.daml
+++ b/test/src/Test/Finance/Asset.daml
@@ -5,7 +5,7 @@ module Test.Finance.Asset where
 
 import DA.Assert
 import DA.Finance.Asset
-import qualified DA.Next.Map as Map
+import qualified DA.Map as Map
 import Daml.Script
 
 import Test.Finance.Market.Asset

--- a/test/src/Test/Finance/Asset/Settlement.daml
+++ b/test/src/Test/Finance/Asset/Settlement.daml
@@ -4,8 +4,8 @@
 module Test.Finance.Asset.Settlement where
 
 import DA.Assert
-import qualified DA.Next.Map as Map
-import DA.Next.Set as Set
+import qualified DA.Map as Map
+import DA.Set as Set
 import Daml.Script
 
 import DA.Finance.Asset

--- a/test/src/Test/Finance/Instrument/Equity/Option.daml
+++ b/test/src/Test/Finance/Instrument/Equity/Option.daml
@@ -6,7 +6,7 @@ module Test.Finance.Instrument.Equity.Option where
 import DA.Assert
 import DA.Date
 import DA.List
-import DA.Next.Set as Set
+import DA.Set as Set
 import DA.Time
 import Daml.Script
 

--- a/test/src/Test/Finance/Instrument/Equity/Stock.daml
+++ b/test/src/Test/Finance/Instrument/Equity/Stock.daml
@@ -6,8 +6,8 @@ module Test.Finance.Instrument.Equity.Stock where
 import DA.Assert
 import DA.Date
 import DA.List
-import DA.Next.Set as Set
-import qualified DA.Next.Map as Map
+import DA.Set as Set
+import qualified DA.Map as Map
 import DA.Time
 import Daml.Script
 

--- a/test/src/Test/Finance/Market/Asset.daml
+++ b/test/src/Test/Finance/Market/Asset.daml
@@ -4,8 +4,8 @@
 module Test.Finance.Market.Asset where
 
 import DA.Action
-import DA.Next.Map as Map
-import DA.Next.Set as Set
+import DA.Map as Map
+import DA.Set as Set
 import DA.Text
 import Daml.Script
 

--- a/test/src/Test/Finance/Market/Dvp.daml
+++ b/test/src/Test/Finance/Market/Dvp.daml
@@ -5,8 +5,8 @@ module Test.Finance.Market.Dvp where
 
 import DA.Action
 import DA.List
-import DA.Next.Map as Map
-import DA.Next.Set as Set
+import DA.Map as Map
+import DA.Set as Set
 import Daml.Script
 
 import DA.Finance.Trade.Dvp

--- a/test/src/Test/Finance/Market/Instrument.daml
+++ b/test/src/Test/Finance/Market/Instrument.daml
@@ -3,8 +3,8 @@
 
 module Test.Finance.Market.Instrument where
 
-import DA.Next.Map as Map
-import DA.Next.Set as Set
+import DA.Map as Map
+import DA.Set as Set
 import Daml.Script
 
 import DA.Finance.Instrument.Equity.Option

--- a/test/src/Test/Finance/Trade/Dvp.daml
+++ b/test/src/Test/Finance/Trade/Dvp.daml
@@ -5,7 +5,7 @@ module Test.Finance.Trade.Dvp where
 
 import DA.Assert
 import DA.List
-import DA.Next.Set as Set
+import DA.Set as Set
 import Daml.Script
 
 import DA.Finance.Trade.Dvp.Settlement

--- a/test/src/Test/Finance/Utils.daml
+++ b/test/src/Test/Finance/Utils.daml
@@ -9,8 +9,8 @@ module Test.Finance.Utils
 
 import DA.Assert
 import DA.List
-import DA.Next.Map as Map
-import DA.Next.Set as Set
+import DA.Map as Map
+import DA.Set as Set
 import DA.Optional
 
 import DA.Finance.Trade.Dvp
@@ -19,27 +19,27 @@ import DA.Finance.Types
 import DA.Finance.Utils
 
 -- | Get first element of Set.
-setFst : MapKey a => Set a -> a
+setFst : Ord a => Set a -> a
 setFst = head . Set.toList
 
 -- | Get second element of Set or first if it does not exist.
-setSndOrFirst : MapKey a => Set a -> a
+setSndOrFirst : Ord a => Set a -> a
 setSndOrFirst s = case Set.toList s of
                   _::(x::xs)  -> x
                   x::xs       -> x
                   _           -> error "empty set"
 
 -- | Insert multiple elements into a map.
-mapInsertMany : MapKey k => [(k, v)] -> Map k v -> Map k v
+mapInsertMany : Ord k => [(k, v)] -> Map k v -> Map k v
 mapInsertMany kvs m = foldl (\m (k, v) -> Map.insert k v m) m kvs
 
 -- | Get values from a map
-mapValues : MapKey k => Map k v -> [v]
+mapValues : Ord k => Map k v -> [v]
 mapValues = map snd . Map.toList
 
 infixl 9 !
 -- | Find the value at a key. Calls error when the element can not be found.
-(!) : (Show k, MapKey k) => Map k v -> k -> v
+(!) : (Show k, Ord k) => Map k v -> k -> v
 (!) m x = fromSomeNote ("key " <> show x <> " does not exist, " <> show (map fst $ Map.toList m)) $ Map.lookup x m
 
 -- | Init asset id.

--- a/test/src/Test/StartupScript.daml
+++ b/test/src/Test/StartupScript.daml
@@ -6,7 +6,7 @@ module Test.StartupScript where
 import DA.Date
 import DA.Foldable
 import DA.List
-import DA.Next.Set as Set
+import DA.Set as Set
 import Daml.Script
 
 import DA.Finance.Instrument.Equity.Option

--- a/test/src/Test/Trigger/Finance/TestScript.daml
+++ b/test/src/Test/Trigger/Finance/TestScript.daml
@@ -7,8 +7,8 @@ module Test.Trigger.Finance.TestScript where
 import DA.Assert
 import DA.Date
 import DA.List as List
-import DA.Next.Set as Set
-import DA.Next.Map as Map
+import DA.Set as Set
+import DA.Map as Map
 import DA.Foldable hiding (all, and)
 import Daml.Script
 import Prelude hiding (submit)

--- a/trigger/daml.yaml
+++ b/trigger/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.7.0
+sdk-version: 1.12.0
 name: finlib-trigger
 version: 2.0.0
 source: src

--- a/trigger/src/DA/Trigger/Finance/Trade/SettlementInstruction.daml
+++ b/trigger/src/DA/Trigger/Finance/Trade/SettlementInstruction.daml
@@ -6,7 +6,7 @@ module DA.Trigger.Finance.Trade.SettlementInstruction where
 import DA.Action (when)
 import DA.Foldable as F (forA_, foldMap)
 import DA.List (head, tail)
-import DA.Next.Map as Map (lookup)
+import DA.Map as Map (lookup)
 import DA.Optional (fromSome, isNone)
 import Daml.Trigger
 

--- a/trigger/src/DA/Trigger/Finance/Utils.daml
+++ b/trigger/src/DA/Trigger/Finance/Utils.daml
@@ -8,10 +8,10 @@ module DA.Trigger.Finance.Utils
   )
   where
 
-import DA.Next.Map as Map
+import DA.Map as Map
 import DA.List as List
 import DA.Record
-import DA.Next.Set as Set
+import DA.Set as Set
 import DA.Time
 import Daml.Trigger
 
@@ -23,7 +23,7 @@ import DA.Finance.Types
 import DA.Finance.Utils
 
 -- | Create a map from a list by applying a key generating function.
-fromListWithKey : MapKey k => (v -> k) -> [v] -> Map k [v]
+fromListWithKey : Ord k => (v -> k) -> [v] -> Map k [v]
 fromListWithKey toKey vs = Map.fromListWith (++) $ map (\v -> (toKey v, [v])) vs
 
 -- | ExerciseByKey if the contract with the specified key exists.


### PR DESCRIPTION
DA.Next.Map and DA.Next.Set are marked deprecated and as such generate warnings on build. This pr migrates the module references to use the recommended DA.Map and DA.Set. In addition the sdkversion is bumped.