### PR TITLE
remove dependency on DA.Optional.Total

### DIFF
--- a/model/src/DA/Finance/Instrument/Equity/Option/Lifecycle.daml
+++ b/model/src/DA/Finance/Instrument/Equity/Option/Lifecycle.daml
@@ -6,7 +6,7 @@ module DA.Finance.Instrument.Equity.Option.Lifecycle where
 import DA.Action
 import DA.Assert
 import DA.Set
-import DA.Optional.Total
+import DA.Optional
 
 import DA.Finance.Asset.Lifecycle
 import DA.Finance.Instrument.Entitlement
@@ -67,11 +67,11 @@ template EquityOptionExerciseRule
                 create Entitlement with id = entitlementId, ..
 
               CASH -> do
-                underlyingPrice <- fromSomeNote "underlying price required for CASH settlement" underlyingPrice
+                let someUnderlyingPrice = fromSomeNote "underlying price required for CASH settlement" underlyingPrice
                 let quantity =
                        case optionType of
-                        CALL -> contractSize * (underlyingPrice - strike)
-                        PUT -> contractSize * (strike - underlyingPrice)
+                        CALL -> contractSize * (someUnderlyingPrice - strike)
+                        PUT -> contractSize * (strike - someUnderlyingPrice)
                 let underlying = Asset with id = stock.ccy, quantity
                 let payment = None
                 create Entitlement with id = entitlementId, ..

--- a/model/src/DA/Finance/Trade/SettlementInstruction.daml
+++ b/model/src/DA/Finance/Trade/SettlementInstruction.daml
@@ -7,8 +7,7 @@ import DA.Assert
 import DA.Either
 import DA.List
 import DA.Set hiding (null)
-import DA.Optional hiding (fromSomeNote)
-import DA.Optional.Total (fromSomeNote)
+import DA.Optional
 
 import DA.Finance.Asset
 import DA.Finance.Asset.Settlement
@@ -67,7 +66,7 @@ template SettlementInstruction
           -- ^ The next sender.
       controller ctrl
       do
-        sender <- fromSomeNote "fully allocated already" $ nextSender this
+        let sender = fromSomeNote "fully allocated already" $ nextSender this
         assertMsg "expecting controller to be next sender" $ ctrl == sender
 
         deposit <- fetch depositCid


### PR DESCRIPTION
DA.Optional.Total has been removed in https://github.com/digital-asset/daml/commit/0852c8f6fa18730f1f0397dfed4fb74759b7edd1, which is causing lib-finance to break when testing with a 2.x Daml SDK snapshot. 

DA.Optional.Total.fromSomeNote was used only within an Update block, where it seems to be equivalent to DA.Optional.fromSomeNote (the same exception is being thrown in DAML script in the unhappy case). Hence, I replaced the former with the latter.

Tests run using daml test are successful.